### PR TITLE
DMs: Pre-select existing DM relays in relay chooser

### DIFF
--- a/Nostur/Relays/Kind10002ConfigurationWizard.swift
+++ b/Nostur/Relays/Kind10002ConfigurationWizard.swift
@@ -567,6 +567,21 @@ struct UpgradeDMsSheet: View {
             account = AccountsState.shared.accounts.first(where: { $0.publicKey == accountPubkey })
             didLoad = true
         }
+        .task {
+            // Pre-select already configured DM relays (from kind 10050 event) and ensure they appear in the list
+            let existingDMRelays = await getDMrelays(for: accountPubkey)
+            for dmRelayUrl in existingDMRelays {
+                let relayData = RelayData.new(url: dmRelayUrl, read: true, write: false, search: false, auth: true, excludedPubkeys: [])
+                if !relayOptions.contains(where: { $0.url == dmRelayUrl }) {
+                    relayOptions.append(relayData)
+                }
+                if let existing = relayOptions.first(where: { $0.url == dmRelayUrl }) {
+                    selectedRelays.insert(existing)
+                } else {
+                    selectedRelays.insert(relayData)
+                }
+            }
+        }
     }
     
     @State private var didLoad = false


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                         
  - When opening "Choose relays for private messages", pre-select relays already configured in the user's kind 10050 event                                                                           
  - Ensure configured DM relays appear in the list even if they aren't marked as "read" relays in CloudRelay                                                                                         
