### PR TITLE
feat: Namecoin (.bit) NIP-05 resolution

### DIFF
--- a/Nostur/Nostr/NIP05Verifier.swift
+++ b/Nostur/Nostr/NIP05Verifier.swift
@@ -31,8 +31,17 @@ class NIP05Verifier {
             .filter { contact in
                 return (contact.nip05verifiedAt == nil || (contact.nip05verifiedAt != nil) && (contact.nip05verifiedAt! < Self.fourWeeksAgo))
             }
+            .handleEvents(receiveOutput: { [weak self] contact in
+                // Namecoin (.bit) verification path — sidecar; does not affect the
+                // HTTP pipeline below. Dispatched async so it doesn't block.
+                guard let nip05 = contact.nip05?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      NamecoinResolver.isNamecoinIdentifier(nip05) else { return }
+                self?.verifyNamecoin(contact: contact, nip05: nip05)
+            })
             .filter { contact in
                 let nip05trimmed = contact.nip05!.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Namecoin identifiers are handled in the sidecar above.
+                if NamecoinResolver.isNamecoinIdentifier(nip05trimmed) { return false }
                 let nip05parts = nip05trimmed.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: true)
                 return nip05parts.count == 2
             }
@@ -77,6 +86,39 @@ class NIP05Verifier {
             .store(in: &cancellables)
     }
     
+    /// Namecoin (.bit) verification sidecar. Resolves via ElectrumX and, if
+    /// the resolved pubkey matches, marks nip05verifiedAt on the Contact.
+    /// Captures only value types into the Task to stay Sendable-clean.
+    private func verifyNamecoin(contact: Contact, nip05: String) {
+        let pubkey = contact.pubkey
+        Task.detached {
+            guard let result = await NamecoinService.shared.resolve(nip05) else { return }
+            guard result.pubkey == pubkey else {
+                #if DEBUG
+                print("[Namecoin] nip05 \(nip05) resolved to \(result.pubkey.prefix(8))… but contact pubkey is \(pubkey.prefix(8))…")
+                #endif
+                return
+            }
+            await Self.persistNamecoinVerified(pubkey: pubkey, nip05: nip05)
+        }
+    }
+
+    private static func persistNamecoinVerified(pubkey: String, nip05: String) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let ctx = bg()
+            ctx.perform {
+                if let bgContact = Contact.fetchByPubkey(pubkey, context: ctx) {
+                    bgContact.nip05verifiedAt = Date.now
+                    ViewUpdates.shared.nip05updated.send((pubkey, true, nip05, "_"))
+                    #if DEBUG
+                    L.fetching.debug("verifySubject: 👍 namecoin nip05 verified \(nip05)")
+                    #endif
+                }
+                cont.resume()
+            }
+        }
+    }
+
     public func verify(_ contact: Contact) {
 #if DEBUG
         if Thread.isMainThread && ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" {

--- a/Nostur/Nostr/Namecoin/ElectrumXClient.swift
+++ b/Nostur/Nostr/Namecoin/ElectrumXClient.swift
@@ -59,17 +59,25 @@ public actor ElectrumXClient: IElectrumXClient {
     // MARK: - Public API
 
     public func nameShowWithFallback(identifier: String, servers: [ElectrumXServer]) async throws -> NameShowResult? {
+        NSLog("[Namecoin] nameShowWithFallback identifier=%{public}@ servers=%d", identifier, servers.count)
         var lastError: Error?
         for server in servers {
+            NSLog("[Namecoin] trying server %{public}@:%d", server.host, server.port)
             do {
                 if let result = try await nameShow(identifier: identifier, server: server) {
+                    NSLog("[Namecoin] nameShow SUCCESS via %{public}@:%d name=%{public}@ value.len=%d", server.host, server.port, result.name, result.value.count)
                     return result
+                } else {
+                    NSLog("[Namecoin] nameShow returned nil (no matching vout) via %{public}@:%d", server.host, server.port)
                 }
             } catch NamecoinLookupError.nameNotFound(let n) {
+                NSLog("[Namecoin] nameNotFound via %{public}@:%d for %{public}@", server.host, server.port, n)
                 throw NamecoinLookupError.nameNotFound(n)
             } catch NamecoinLookupError.nameExpired(let n) {
+                NSLog("[Namecoin] nameExpired via %{public}@:%d for %{public}@", server.host, server.port, n)
                 throw NamecoinLookupError.nameExpired(n)
             } catch {
+                NSLog("[Namecoin] server %{public}@:%d FAILED: %{public}@", server.host, server.port, String(describing: error))
                 lastError = error
             }
         }
@@ -79,7 +87,9 @@ public actor ElectrumXClient: IElectrumXClient {
     }
 
     public func nameShow(identifier: String, server: ElectrumXServer) async throws -> NameShowResult? {
+        NSLog("[Namecoin] nameShow connecting %{public}@:%d", server.host, server.port)
         let conn = try await openConnection(server: server)
+        NSLog("[Namecoin] nameShow connected")
         defer { conn.cancel() }
 
         let io = LineIO(connection: conn, rpcTimeout: rpcTimeout)
@@ -87,7 +97,8 @@ public actor ElectrumXClient: IElectrumXClient {
         // 1. Version handshake
         let versionReq = try buildRpcRequest(method: "server.version", params: [.string("Nostur/1.0"), .string(Self.PROTOCOL_VERSION)])
         try await io.writeLine(versionReq)
-        _ = try await io.readLine()
+        let verLine = try await io.readLine()
+        NSLog("[Namecoin] version resp len=%d", verLine?.count ?? -1)
 
         // 2. Build scripthash for the name
         guard let nameBytes = identifier.data(using: .utf8) else {
@@ -95,14 +106,21 @@ public actor ElectrumXClient: IElectrumXClient {
         }
         let script = Self.buildNameIndexScript(nameBytes: [UInt8](nameBytes))
         let scriptHash = Self.electrumScriptHash(script: script)
+        NSLog("[Namecoin] scripthash=%{public}@ (for %{public}@)", scriptHash, identifier)
 
         // 3. Get history for this scripthash
         let historyReq = try buildRpcRequest(method: "blockchain.scripthash.get_history", params: [.string(scriptHash)])
         try await io.writeLine(historyReq)
-        guard let historyLine = try await io.readLine() else { return nil }
+        guard let historyLine = try await io.readLine() else {
+            NSLog("[Namecoin] history EOF/nil")
+            return nil
+        }
+        NSLog("[Namecoin] history resp len=%d", historyLine.count)
         guard let history = Self.parseHistoryResponse(historyLine) else {
+            NSLog("[Namecoin] bad history response: %{public}@", String(historyLine.prefix(300)))
             throw NamecoinLookupError.invalidResponse("bad history response")
         }
+        NSLog("[Namecoin] history entries=%d", history.count)
         guard !history.isEmpty else {
             throw NamecoinLookupError.nameNotFound(identifier)
         }
@@ -111,27 +129,36 @@ public actor ElectrumXClient: IElectrumXClient {
         let latest = history.last!
         let txHash = latest.txHash
         let height = latest.height
+        NSLog("[Namecoin] latest tx=%{public}@ height=%d", txHash, height)
 
         let txReq = try buildRpcRequest(method: "blockchain.transaction.get", params: [.string(txHash), .bool(true)])
         try await io.writeLine(txReq)
-        guard let txLine = try await io.readLine() else { return nil }
+        guard let txLine = try await io.readLine() else {
+            NSLog("[Namecoin] tx EOF/nil")
+            return nil
+        }
+        NSLog("[Namecoin] tx resp len=%d", txLine.count)
 
         // 5. Current block height for expiry check
         let hdrsReq = try buildRpcRequest(method: "blockchain.headers.subscribe", params: [])
         try await io.writeLine(hdrsReq)
         let hdrsLine = try await io.readLine()
         let currentHeight = Self.parseBlockHeight(hdrsLine)
+        NSLog("[Namecoin] hdrs currentHeight=%d", currentHeight ?? -1)
 
         // 6. Check expiry
         if let currentHeight = currentHeight, height > 0 {
             let blocksSince = currentHeight - height
             if blocksSince >= Self.NAME_EXPIRE_DEPTH {
+                NSLog("[Namecoin] EXPIRED blocksSince=%d (depth=%d)", blocksSince, Self.NAME_EXPIRE_DEPTH)
                 throw NamecoinLookupError.nameExpired(identifier)
             }
         }
 
         // 7. Parse the name/value from the tx
-        return Self.parseNameFromTransaction(identifier: identifier, txHash: txHash, height: height, raw: txLine)
+        let parsed = Self.parseNameFromTransaction(identifier: identifier, txHash: txHash, height: height, raw: txLine)
+        NSLog("[Namecoin] parseNameFromTransaction -> %{public}@", parsed.map { "name=\($0.name) value.len=\($0.value.count)" } ?? "nil")
+        return parsed
     }
 
     // MARK: - Connection
@@ -282,22 +309,42 @@ public actor ElectrumXClient: IElectrumXClient {
     private static func parseNameFromTransaction(identifier: String, txHash: String, height: Int, raw: String) -> NameShowResult? {
         guard let data = raw.data(using: .utf8),
               let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-        if let err = envelope["error"], !(err is NSNull) { return nil }
+        else {
+            NSLog("[Namecoin] parseNameFromTransaction: envelope parse failed")
+            return nil
+        }
+        if let err = envelope["error"], !(err is NSNull) {
+            NSLog("[Namecoin] parseNameFromTransaction: envelope has error=%{public}@", String(describing: err))
+            return nil
+        }
         guard let result = envelope["result"] as? [String: Any],
               let vouts = result["vout"] as? [[String: Any]]
-        else { return nil }
-
-        for vout in vouts {
+        else {
+            NSLog("[Namecoin] parseNameFromTransaction: no result.vout")
+            return nil
+        }
+        NSLog("[Namecoin] parseNameFromTransaction: vouts=%d", vouts.count)
+        for (i, vout) in vouts.enumerated() {
             guard let spk = vout["scriptPubKey"] as? [String: Any],
                   let hex = spk["hex"] as? String else { continue }
-            if !hex.hasPrefix("53") { continue }
-            guard let bytes = hexToBytes(hex) else { continue }
-            guard let (name, value) = parseNameScript(bytes) else { continue }
+            if !hex.hasPrefix("53") {
+                NSLog("[Namecoin] vout[%d] no 53 prefix (hex[:10]=%{public}@)", i, String(hex.prefix(10)))
+                continue
+            }
+            guard let bytes = hexToBytes(hex) else {
+                NSLog("[Namecoin] vout[%d] hexToBytes failed", i)
+                continue
+            }
+            guard let (name, value) = parseNameScript(bytes) else {
+                NSLog("[Namecoin] vout[%d] parseNameScript failed", i)
+                continue
+            }
+            NSLog("[Namecoin] vout[%d] parsed name=%{public}@ valueLen=%d (want %{public}@)", i, name, value.count, identifier)
             if name == identifier {
                 return NameShowResult(name: name, value: value, txid: txHash, height: height)
             }
         }
+        NSLog("[Namecoin] parseNameFromTransaction: no matching name found")
         return nil
     }
 

--- a/Nostur/Nostr/Namecoin/ElectrumXClient.swift
+++ b/Nostur/Nostr/Namecoin/ElectrumXClient.swift
@@ -1,0 +1,501 @@
+//
+//  ElectrumXClient.swift
+//  Nostur
+//
+//  ElectrumX JSON-RPC client for Namecoin name resolution.
+//
+//  TLS is implemented with Apple's Network.framework (`NWConnection` +
+//  `NWProtocolTLS.Options` + `sec_protocol_options_set_verify_block`).
+//  This is the approach amethyst iOS settled on after discovering that
+//  SecureTransport (`SSLCreateContext`) does not honour `break-on-server-auth`
+//  for self-signed certs on iOS — it returns errSSLPeerUnknownCA (-9841)
+//  before the break-on-auth callback fires.
+//  See amethyst PR #2199, commit 07ca8f0.
+//
+//  The native Swift port avoids all K/N cinterop complications — we can
+//  pass Swift closures directly to `sec_protocol_options_set_verify_block`.
+//
+//  Resolution flow (same as JVM/Android/K-N):
+//    1. Connect (TLS TCP, newline-delimited JSON-RPC).
+//    2. `server.version` handshake.
+//    3. Build canonical "name index" script for the identifier.
+//    4. SHA-256 + byte-reverse → Electrum scripthash.
+//    5. `blockchain.scripthash.get_history` → list of [txhash, height].
+//    6. Fetch the latest tx via `blockchain.transaction.get`.
+//    7. Check current block height for expiry (NAME_EXPIRE_DEPTH = 36000).
+//    8. Parse name value from the tx's OP_NAME_UPDATE scriptPubKey.
+//
+
+import CryptoKit
+import Foundation
+import Network
+
+public protocol IElectrumXClient {
+    /// Resolve a Namecoin name (e.g. "d/testls") by trying each server until one succeeds.
+    func nameShowWithFallback(identifier: String, servers: [ElectrumXServer]) async throws -> NameShowResult?
+}
+
+public actor ElectrumXClient: IElectrumXClient {
+    // MARK: - Config
+
+    private static let PROTOCOL_VERSION = "1.4"
+    /// Namecoin name expiry depth in blocks (~200 days).
+    private static let NAME_EXPIRE_DEPTH = 36_000
+
+    private static let OP_NAME_UPDATE: UInt8 = 0x53
+    private static let OP_2DROP: UInt8 = 0x6d
+    private static let OP_DROP: UInt8 = 0x75
+    private static let OP_RETURN: UInt8 = 0x6a
+    private static let OP_PUSHDATA1: UInt8 = 0x4c
+    private static let OP_PUSHDATA2: UInt8 = 0x4d
+
+    private let connectTimeout: TimeInterval = 10
+    private let rpcTimeout: TimeInterval = 15
+
+    private var requestId = 0
+
+    public init() {}
+
+    // MARK: - Public API
+
+    public func nameShowWithFallback(identifier: String, servers: [ElectrumXServer]) async throws -> NameShowResult? {
+        var lastError: Error?
+        for server in servers {
+            do {
+                if let result = try await nameShow(identifier: identifier, server: server) {
+                    return result
+                }
+            } catch NamecoinLookupError.nameNotFound(let n) {
+                throw NamecoinLookupError.nameNotFound(n)
+            } catch NamecoinLookupError.nameExpired(let n) {
+                throw NamecoinLookupError.nameExpired(n)
+            } catch {
+                lastError = error
+            }
+        }
+        throw NamecoinLookupError.serversUnreachable(
+            lastError.map { "\($0)" } ?? "All ElectrumX servers unreachable"
+        )
+    }
+
+    public func nameShow(identifier: String, server: ElectrumXServer) async throws -> NameShowResult? {
+        let conn = try await openConnection(server: server)
+        defer { conn.cancel() }
+
+        let io = LineIO(connection: conn, rpcTimeout: rpcTimeout)
+
+        // 1. Version handshake
+        let versionReq = try buildRpcRequest(method: "server.version", params: [.string("Nostur/1.0"), .string(Self.PROTOCOL_VERSION)])
+        try await io.writeLine(versionReq)
+        _ = try await io.readLine()
+
+        // 2. Build scripthash for the name
+        guard let nameBytes = identifier.data(using: .utf8) else {
+            throw NamecoinLookupError.invalidResponse("identifier not utf-8")
+        }
+        let script = Self.buildNameIndexScript(nameBytes: [UInt8](nameBytes))
+        let scriptHash = Self.electrumScriptHash(script: script)
+
+        // 3. Get history for this scripthash
+        let historyReq = try buildRpcRequest(method: "blockchain.scripthash.get_history", params: [.string(scriptHash)])
+        try await io.writeLine(historyReq)
+        guard let historyLine = try await io.readLine() else { return nil }
+        guard let history = Self.parseHistoryResponse(historyLine) else {
+            throw NamecoinLookupError.invalidResponse("bad history response")
+        }
+        guard !history.isEmpty else {
+            throw NamecoinLookupError.nameNotFound(identifier)
+        }
+
+        // 4. Fetch the latest transaction
+        let latest = history.last!
+        let txHash = latest.txHash
+        let height = latest.height
+
+        let txReq = try buildRpcRequest(method: "blockchain.transaction.get", params: [.string(txHash), .bool(true)])
+        try await io.writeLine(txReq)
+        guard let txLine = try await io.readLine() else { return nil }
+
+        // 5. Current block height for expiry check
+        let hdrsReq = try buildRpcRequest(method: "blockchain.headers.subscribe", params: [])
+        try await io.writeLine(hdrsReq)
+        let hdrsLine = try await io.readLine()
+        let currentHeight = Self.parseBlockHeight(hdrsLine)
+
+        // 6. Check expiry
+        if let currentHeight = currentHeight, height > 0 {
+            let blocksSince = currentHeight - height
+            if blocksSince >= Self.NAME_EXPIRE_DEPTH {
+                throw NamecoinLookupError.nameExpired(identifier)
+            }
+        }
+
+        // 7. Parse the name/value from the tx
+        return Self.parseNameFromTransaction(identifier: identifier, txHash: txHash, height: height, raw: txLine)
+    }
+
+    // MARK: - Connection
+
+    /// Open a TLS NWConnection, waiting for .ready or failure.
+    private func openConnection(server: ElectrumXServer) async throws -> NWConnection {
+        let params = Self.makeTLSParams(server: server)
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(server.host), port: NWEndpoint.Port(integerLiteral: UInt16(server.port)))
+        let connection = NWConnection(to: endpoint, using: params)
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let finished = FinishedBox()
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    if finished.set() { cont.resume() }
+                case .failed(let err):
+                    if finished.set() { cont.resume(throwing: NamecoinLookupError.connectionFailed("\(err)")) }
+                case .cancelled:
+                    if finished.set() { cont.resume(throwing: NamecoinLookupError.connectionFailed("cancelled")) }
+                default:
+                    break
+                }
+            }
+
+            connection.start(queue: NamecoinQueues.network)
+
+            // Connect timeout
+            NamecoinQueues.network.asyncAfter(deadline: .now() + connectTimeout) {
+                if finished.set() {
+                    connection.cancel()
+                    cont.resume(throwing: NamecoinLookupError.connectionFailed("connect timeout"))
+                }
+            }
+        }
+
+        return connection
+    }
+
+    // MARK: - TLS parameters (trust-all + TOFU pinning)
+
+    private static func makeTLSParams(server: ElectrumXServer) -> NWParameters {
+        let tlsOpts = NWProtocolTLS.Options()
+        let secOpts = tlsOpts.securityProtocolOptions
+
+        // Set SNI so servers with vhosts return the right cert.
+        sec_protocol_options_set_tls_server_name(secOpts, server.host)
+
+        if server.usePinnedTrustStore {
+            sec_protocol_options_set_verify_block(secOpts, { _, sec_trust, complete in
+                // Capture the leaf certificate's SHA-256 fingerprint for TOFU.
+                let trust = sec_trust_copy_ref(sec_trust).takeRetainedValue()
+                var derFingerprint: String?
+                if SecTrustGetCertificateCount(trust) > 0,
+                   let leaf = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+                   let first = leaf.first {
+                    let der = SecCertificateCopyData(first) as Data
+                    derFingerprint = NamecoinCertPinning.fingerprint(der: der)
+                }
+
+                // TOFU logic: if we have a pinned fp, must match. Else, pin.
+                if let fp = derFingerprint {
+                    if let pinned = NamecoinCertPinning.pinned(for: server) {
+                        if pinned == fp {
+                            complete(true)
+                        } else {
+                            #if DEBUG
+                            print("[Namecoin] TLS pin MISMATCH for \(server.host):\(server.port) (expected \(pinned.prefix(16))… got \(fp.prefix(16))…)")
+                            #endif
+                            complete(false)
+                        }
+                    } else {
+                        NamecoinCertPinning.pinIfMissing(server: server, fingerprint: fp)
+                        complete(true)
+                    }
+                } else {
+                    // No cert? Don't trust.
+                    complete(false)
+                }
+            }, NamecoinQueues.network)
+        }
+
+        let tcpOpts = NWProtocolTCP.Options()
+        tcpOpts.connectionTimeout = 10
+        let params = NWParameters(tls: tlsOpts, tcp: tcpOpts)
+        return params
+    }
+
+    // MARK: - JSON-RPC encoding
+
+    private enum RpcParam {
+        case string(String)
+        case int(Int)
+        case bool(Bool)
+    }
+
+    private func buildRpcRequest(method: String, params: [RpcParam]) throws -> String {
+        requestId += 1
+        var obj: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": requestId,
+            "method": method,
+        ]
+        obj["params"] = params.map { param -> Any in
+            switch param {
+            case .string(let s): return s
+            case .int(let i): return i
+            case .bool(let b): return b
+            }
+        }
+        let data = try JSONSerialization.data(withJSONObject: obj, options: [])
+        guard let s = String(data: data, encoding: .utf8) else {
+            throw NamecoinLookupError.invalidResponse("json encoding")
+        }
+        return s
+    }
+
+    // MARK: - Response parsing
+
+    private struct HistoryEntry {
+        let txHash: String
+        let height: Int
+    }
+
+    private static func parseHistoryResponse(_ raw: String) -> [HistoryEntry]? {
+        guard let data = raw.data(using: .utf8),
+              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        if let err = envelope["error"], !(err is NSNull) { return nil }
+        guard let result = envelope["result"] as? [[String: Any]] else { return nil }
+        return result.compactMap { entry -> HistoryEntry? in
+            guard let txHash = entry["tx_hash"] as? String,
+                  let height = entry["height"] as? Int else { return nil }
+            return HistoryEntry(txHash: txHash, height: height)
+        }
+    }
+
+    private static func parseBlockHeight(_ raw: String?) -> Int? {
+        guard let raw = raw,
+              let data = raw.data(using: .utf8),
+              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let result = envelope["result"] as? [String: Any],
+              let h = result["height"] as? Int
+        else { return nil }
+        return h
+    }
+
+    private static func parseNameFromTransaction(identifier: String, txHash: String, height: Int, raw: String) -> NameShowResult? {
+        guard let data = raw.data(using: .utf8),
+              let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        if let err = envelope["error"], !(err is NSNull) { return nil }
+        guard let result = envelope["result"] as? [String: Any],
+              let vouts = result["vout"] as? [[String: Any]]
+        else { return nil }
+
+        for vout in vouts {
+            guard let spk = vout["scriptPubKey"] as? [String: Any],
+                  let hex = spk["hex"] as? String else { continue }
+            if !hex.hasPrefix("53") { continue }
+            guard let bytes = hexToBytes(hex) else { continue }
+            guard let (name, value) = parseNameScript(bytes) else { continue }
+            if name == identifier {
+                return NameShowResult(name: name, value: value, txid: txHash, height: height)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Script construction
+
+    /// Build the canonical script used by ElectrumX to index Namecoin names:
+    ///   OP_NAME_UPDATE <push(name)> <push(empty)> OP_2DROP OP_DROP OP_RETURN
+    private static func buildNameIndexScript(nameBytes: [UInt8]) -> [UInt8] {
+        var out: [UInt8] = []
+        out.append(OP_NAME_UPDATE)
+        out.append(contentsOf: pushData(nameBytes))
+        out.append(contentsOf: pushData([]))
+        out.append(OP_2DROP)
+        out.append(OP_DROP)
+        out.append(OP_RETURN)
+        return out
+    }
+
+    private static func pushData(_ data: [UInt8]) -> [UInt8] {
+        let len = data.count
+        if len < 0x4c {
+            return [UInt8(len)] + data
+        } else if len <= 0xff {
+            return [OP_PUSHDATA1, UInt8(len)] + data
+        } else {
+            let lo = UInt8(len & 0xff)
+            let hi = UInt8((len >> 8) & 0xff)
+            return [OP_PUSHDATA2, lo, hi] + data
+        }
+    }
+
+    /// Electrum scripthash: SHA-256 of the script, byte-reversed, as hex.
+    private static func electrumScriptHash(script: [UInt8]) -> String {
+        let digest = SHA256.hash(data: Data(script))
+        let reversed = Array(digest.reversed())
+        return reversed.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Script parsing
+
+    private static func parseNameScript(_ script: [UInt8]) -> (String, String)? {
+        guard !script.isEmpty, script[0] == OP_NAME_UPDATE else { return nil }
+        var pos = 1
+        guard let (nameBytes, p1) = readPushData(script, pos: pos) else { return nil }
+        pos = p1
+        guard let (valueBytes, _) = readPushData(script, pos: pos) else { return nil }
+        guard let name = String(bytes: nameBytes, encoding: .utf8),
+              let value = String(bytes: valueBytes, encoding: .utf8) else { return nil }
+        return (name, value)
+    }
+
+    private static func readPushData(_ script: [UInt8], pos: Int) -> ([UInt8], Int)? {
+        guard pos < script.count else { return nil }
+        let opcode = Int(script[pos])
+        switch opcode {
+        case 0:
+            return ([], pos + 1)
+        case 0x01..<0x4c:
+            let end = pos + 1 + opcode
+            guard end <= script.count else { return nil }
+            return (Array(script[(pos + 1)..<end]), end)
+        case 0x4c:
+            guard pos + 2 <= script.count else { return nil }
+            let len = Int(script[pos + 1])
+            let end = pos + 2 + len
+            guard end <= script.count else { return nil }
+            return (Array(script[(pos + 2)..<end]), end)
+        case 0x4d:
+            guard pos + 3 <= script.count else { return nil }
+            let len = Int(script[pos + 1]) | (Int(script[pos + 2]) << 8)
+            let end = pos + 3 + len
+            guard end <= script.count else { return nil }
+            return (Array(script[(pos + 3)..<end]), end)
+        default:
+            return nil
+        }
+    }
+
+    private static func hexToBytes(_ hex: String) -> [UInt8]? {
+        let chars = Array(hex)
+        guard chars.count % 2 == 0 else { return nil }
+        var out: [UInt8] = []
+        out.reserveCapacity(chars.count / 2)
+        var i = 0
+        while i < chars.count {
+            guard let hi = hexVal(chars[i]), let lo = hexVal(chars[i + 1]) else { return nil }
+            out.append(UInt8((hi << 4) | lo))
+            i += 2
+        }
+        return out
+    }
+
+    private static func hexVal(_ c: Character) -> Int? {
+        switch c {
+        case "0"..."9": return Int(c.asciiValue! - 48)
+        case "a"..."f": return Int(c.asciiValue! - 87)
+        case "A"..."F": return Int(c.asciiValue! - 55)
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Serial queue for all Namecoin Network.framework I/O.
+enum NamecoinQueues {
+    static let network = DispatchQueue(label: "nostur.namecoin.network", qos: .userInitiated)
+}
+
+/// One-shot "finished" flag safe for concurrent callbacks.
+private final class FinishedBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+    /// Returns true if *this* call set the flag.
+    func set() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if done { return false }
+        done = true
+        return true
+    }
+}
+
+/// Line-buffered async I/O wrapper around NWConnection.
+/// Not thread-safe; call sequentially from a single actor.
+private final class LineIO: @unchecked Sendable {
+    private let connection: NWConnection
+    private let rpcTimeout: TimeInterval
+    private var buffer = Data()
+
+    init(connection: NWConnection, rpcTimeout: TimeInterval) {
+        self.connection = connection
+        self.rpcTimeout = rpcTimeout
+    }
+
+    func writeLine(_ line: String) async throws {
+        let payload = (line + "\n").data(using: .utf8) ?? Data()
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let finished = FinishedBox()
+            connection.send(content: payload, completion: .contentProcessed { err in
+                if let err = err {
+                    if finished.set() { cont.resume(throwing: NamecoinLookupError.connectionFailed("send: \(err)")) }
+                } else {
+                    if finished.set() { cont.resume() }
+                }
+            })
+        }
+    }
+
+    /// Reads one newline-terminated frame, or nil on clean EOF.
+    func readLine() async throws -> String? {
+        // Try to serve from buffer first.
+        if let line = popLine() { return line }
+
+        let deadline = Date().addingTimeInterval(rpcTimeout)
+        while Date() < deadline {
+            let chunk = try await receiveChunk()
+            if chunk.isEmpty {
+                // EOF — flush whatever is left as a final "line".
+                if !buffer.isEmpty {
+                    let s = String(data: buffer, encoding: .utf8)
+                    buffer.removeAll()
+                    return s
+                }
+                return nil
+            }
+            buffer.append(chunk)
+            if let line = popLine() { return line }
+        }
+        throw NamecoinLookupError.timeout
+    }
+
+    private func popLine() -> String? {
+        guard let idx = buffer.firstIndex(of: 0x0a) else { return nil }
+        let lineData = buffer.prefix(upTo: idx)
+        buffer.removeSubrange(0...idx)
+        return String(data: lineData, encoding: .utf8)
+    }
+
+    private func receiveChunk() async throws -> Data {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+            let finished = FinishedBox()
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, isComplete, err in
+                if let err = err {
+                    if finished.set() { cont.resume(throwing: NamecoinLookupError.connectionFailed("recv: \(err)")) }
+                    return
+                }
+                if let data = data, !data.isEmpty {
+                    if finished.set() { cont.resume(returning: data) }
+                    return
+                }
+                if isComplete {
+                    if finished.set() { cont.resume(returning: Data()) }
+                    return
+                }
+                // Shouldn't happen (no data, no EOF, no err), but guard anyway
+                if finished.set() { cont.resume(returning: Data()) }
+            }
+        }
+    }
+}

--- a/Nostur/Nostr/Namecoin/ElectrumXClient.swift
+++ b/Nostur/Nostr/Namecoin/ElectrumXClient.swift
@@ -59,25 +59,25 @@ public actor ElectrumXClient: IElectrumXClient {
     // MARK: - Public API
 
     public func nameShowWithFallback(identifier: String, servers: [ElectrumXServer]) async throws -> NameShowResult? {
-        NSLog("[Namecoin] nameShowWithFallback identifier=%{public}@ servers=%d", identifier, servers.count)
+        NSLog("%@", "[Namecoin] nameShowWithFallback identifier=\(identifier) servers=\(servers.count)")
         var lastError: Error?
         for server in servers {
-            NSLog("[Namecoin] trying server %{public}@:%d", server.host, server.port)
+            NSLog("%@", "[Namecoin] trying server \(server.host):\(server.port)")
             do {
                 if let result = try await nameShow(identifier: identifier, server: server) {
-                    NSLog("[Namecoin] nameShow SUCCESS via %{public}@:%d name=%{public}@ value.len=%d", server.host, server.port, result.name, result.value.count)
+                    NSLog("%@", "[Namecoin] nameShow SUCCESS via \(server.host):\(server.port) name=\(result.name) value.len=\(result.value.count)")
                     return result
                 } else {
-                    NSLog("[Namecoin] nameShow returned nil (no matching vout) via %{public}@:%d", server.host, server.port)
+                    NSLog("%@", "[Namecoin] nameShow returned nil (no matching vout) via \(server.host):\(server.port)")
                 }
             } catch NamecoinLookupError.nameNotFound(let n) {
-                NSLog("[Namecoin] nameNotFound via %{public}@:%d for %{public}@", server.host, server.port, n)
+                NSLog("%@", "[Namecoin] nameNotFound via \(server.host):\(server.port) for \(n)")
                 throw NamecoinLookupError.nameNotFound(n)
             } catch NamecoinLookupError.nameExpired(let n) {
-                NSLog("[Namecoin] nameExpired via %{public}@:%d for %{public}@", server.host, server.port, n)
+                NSLog("%@", "[Namecoin] nameExpired via \(server.host):\(server.port) for \(n)")
                 throw NamecoinLookupError.nameExpired(n)
             } catch {
-                NSLog("[Namecoin] server %{public}@:%d FAILED: %{public}@", server.host, server.port, String(describing: error))
+                NSLog("%@", "[Namecoin] server \(server.host):\(server.port) FAILED: \(error)")
                 lastError = error
             }
         }
@@ -87,7 +87,7 @@ public actor ElectrumXClient: IElectrumXClient {
     }
 
     public func nameShow(identifier: String, server: ElectrumXServer) async throws -> NameShowResult? {
-        NSLog("[Namecoin] nameShow connecting %{public}@:%d", server.host, server.port)
+        NSLog("%@", "[Namecoin] nameShow connecting \(server.host):\(server.port)")
         let conn = try await openConnection(server: server)
         NSLog("[Namecoin] nameShow connected")
         defer { conn.cancel() }
@@ -98,7 +98,7 @@ public actor ElectrumXClient: IElectrumXClient {
         let versionReq = try buildRpcRequest(method: "server.version", params: [.string("Nostur/1.0"), .string(Self.PROTOCOL_VERSION)])
         try await io.writeLine(versionReq)
         let verLine = try await io.readLine()
-        NSLog("[Namecoin] version resp len=%d", verLine?.count ?? -1)
+        NSLog("%@", "[Namecoin] version resp len=\(verLine?.count ?? -1)")
 
         // 2. Build scripthash for the name
         guard let nameBytes = identifier.data(using: .utf8) else {
@@ -106,7 +106,7 @@ public actor ElectrumXClient: IElectrumXClient {
         }
         let script = Self.buildNameIndexScript(nameBytes: [UInt8](nameBytes))
         let scriptHash = Self.electrumScriptHash(script: script)
-        NSLog("[Namecoin] scripthash=%{public}@ (for %{public}@)", scriptHash, identifier)
+        NSLog("%@", "[Namecoin] scripthash=\(scriptHash) (for \(identifier))")
 
         // 3. Get history for this scripthash
         let historyReq = try buildRpcRequest(method: "blockchain.scripthash.get_history", params: [.string(scriptHash)])
@@ -115,12 +115,12 @@ public actor ElectrumXClient: IElectrumXClient {
             NSLog("[Namecoin] history EOF/nil")
             return nil
         }
-        NSLog("[Namecoin] history resp len=%d", historyLine.count)
+        NSLog("%@", "[Namecoin] history resp len=\(historyLine.count)")
         guard let history = Self.parseHistoryResponse(historyLine) else {
-            NSLog("[Namecoin] bad history response: %{public}@", String(historyLine.prefix(300)))
+            NSLog("%@", "[Namecoin] bad history response: \(String(historyLine.prefix(300)))")
             throw NamecoinLookupError.invalidResponse("bad history response")
         }
-        NSLog("[Namecoin] history entries=%d", history.count)
+        NSLog("%@", "[Namecoin] history entries=\(history.count)")
         guard !history.isEmpty else {
             throw NamecoinLookupError.nameNotFound(identifier)
         }
@@ -129,7 +129,7 @@ public actor ElectrumXClient: IElectrumXClient {
         let latest = history.last!
         let txHash = latest.txHash
         let height = latest.height
-        NSLog("[Namecoin] latest tx=%{public}@ height=%d", txHash, height)
+        NSLog("%@", "[Namecoin] latest tx=\(txHash) height=\(height)")
 
         let txReq = try buildRpcRequest(method: "blockchain.transaction.get", params: [.string(txHash), .bool(true)])
         try await io.writeLine(txReq)
@@ -137,27 +137,27 @@ public actor ElectrumXClient: IElectrumXClient {
             NSLog("[Namecoin] tx EOF/nil")
             return nil
         }
-        NSLog("[Namecoin] tx resp len=%d", txLine.count)
+        NSLog("%@", "[Namecoin] tx resp len=\(txLine.count)")
 
         // 5. Current block height for expiry check
         let hdrsReq = try buildRpcRequest(method: "blockchain.headers.subscribe", params: [])
         try await io.writeLine(hdrsReq)
         let hdrsLine = try await io.readLine()
         let currentHeight = Self.parseBlockHeight(hdrsLine)
-        NSLog("[Namecoin] hdrs currentHeight=%d", currentHeight ?? -1)
+        NSLog("%@", "[Namecoin] hdrs currentHeight=\(currentHeight ?? -1)")
 
         // 6. Check expiry
         if let currentHeight = currentHeight, height > 0 {
             let blocksSince = currentHeight - height
             if blocksSince >= Self.NAME_EXPIRE_DEPTH {
-                NSLog("[Namecoin] EXPIRED blocksSince=%d (depth=%d)", blocksSince, Self.NAME_EXPIRE_DEPTH)
+                NSLog("%@", "[Namecoin] EXPIRED blocksSince=\(blocksSince) (depth=\(Self.NAME_EXPIRE_DEPTH))")
                 throw NamecoinLookupError.nameExpired(identifier)
             }
         }
 
         // 7. Parse the name/value from the tx
         let parsed = Self.parseNameFromTransaction(identifier: identifier, txHash: txHash, height: height, raw: txLine)
-        NSLog("[Namecoin] parseNameFromTransaction -> %{public}@", parsed.map { "name=\($0.name) value.len=\($0.value.count)" } ?? "nil")
+        NSLog("%@", "[Namecoin] parseNameFromTransaction -> \(parsed.map { "name=\($0.name) value.len=\($0.value.count)" } ?? "nil")")
         return parsed
     }
 
@@ -314,7 +314,7 @@ public actor ElectrumXClient: IElectrumXClient {
             return nil
         }
         if let err = envelope["error"], !(err is NSNull) {
-            NSLog("[Namecoin] parseNameFromTransaction: envelope has error=%{public}@", String(describing: err))
+            NSLog("%@", "[Namecoin] parseNameFromTransaction: envelope has error=\(err)")
             return nil
         }
         guard let result = envelope["result"] as? [String: Any],
@@ -323,23 +323,23 @@ public actor ElectrumXClient: IElectrumXClient {
             NSLog("[Namecoin] parseNameFromTransaction: no result.vout")
             return nil
         }
-        NSLog("[Namecoin] parseNameFromTransaction: vouts=%d", vouts.count)
+        NSLog("%@", "[Namecoin] parseNameFromTransaction: vouts=\(vouts.count)")
         for (i, vout) in vouts.enumerated() {
             guard let spk = vout["scriptPubKey"] as? [String: Any],
                   let hex = spk["hex"] as? String else { continue }
             if !hex.hasPrefix("53") {
-                NSLog("[Namecoin] vout[%d] no 53 prefix (hex[:10]=%{public}@)", i, String(hex.prefix(10)))
+                NSLog("%@", "[Namecoin] vout[\(i)] no 53 prefix (hex[:10]=\(String(hex.prefix(10))))")
                 continue
             }
             guard let bytes = hexToBytes(hex) else {
-                NSLog("[Namecoin] vout[%d] hexToBytes failed", i)
+                NSLog("%@", "[Namecoin] vout[\(i)] hexToBytes failed")
                 continue
             }
             guard let (name, value) = parseNameScript(bytes) else {
-                NSLog("[Namecoin] vout[%d] parseNameScript failed", i)
+                NSLog("%@", "[Namecoin] vout[\(i)] parseNameScript failed")
                 continue
             }
-            NSLog("[Namecoin] vout[%d] parsed name=%{public}@ valueLen=%d (want %{public}@)", i, name, value.count, identifier)
+            NSLog("%@", "[Namecoin] vout[\(i)] parsed name=\(name) valueLen=\(value.count) (want \(identifier))")
             if name == identifier {
                 return NameShowResult(name: name, value: value, txid: txHash, height: height)
             }

--- a/Nostur/Nostr/Namecoin/NamecoinCache.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinCache.swift
@@ -1,0 +1,65 @@
+//
+//  NamecoinCache.swift
+//  Nostur
+//
+//  Small in-memory cache for Namecoin resolution results.
+//  Matches the semantics of amethyst's NamecoinLookupCache (1h TTL, 500 entries).
+//
+
+import Foundation
+
+public actor NamecoinCache {
+    public struct Entry: Sendable {
+        public let result: NamecoinNostrResult?
+        public let timestamp: Date
+    }
+
+    public static let shared = NamecoinCache()
+
+    private let maxEntries: Int
+    private let ttl: TimeInterval
+    private var storage: [String: Entry] = [:]
+    private var order: [String] = [] // LRU order, front = oldest
+
+    public init(maxEntries: Int = 500, ttl: TimeInterval = 86_400) {
+        self.maxEntries = maxEntries
+        self.ttl = ttl
+    }
+
+    private func key(_ identifier: String) -> String {
+        identifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    public func get(_ identifier: String) -> Entry? {
+        let k = key(identifier)
+        guard let entry = storage[k] else { return nil }
+        if Date().timeIntervalSince(entry.timestamp) > ttl {
+            storage.removeValue(forKey: k)
+            order.removeAll { $0 == k }
+            return nil
+        }
+        return entry
+    }
+
+    public func put(_ identifier: String, result: NamecoinNostrResult?) {
+        let k = key(identifier)
+        storage[k] = Entry(result: result, timestamp: Date())
+        order.removeAll { $0 == k }
+        order.append(k)
+        while order.count > maxEntries {
+            let evict = order.removeFirst()
+            storage.removeValue(forKey: evict)
+        }
+    }
+
+    public func invalidate(_ identifier: String) {
+        let k = key(identifier)
+        storage.removeValue(forKey: k)
+        order.removeAll { $0 == k }
+    }
+
+    public func clear() {
+        storage.removeAll()
+        order.removeAll()
+    }
+}

--- a/Nostur/Nostr/Namecoin/NamecoinCertPinning.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinCertPinning.swift
@@ -1,0 +1,61 @@
+//
+//  NamecoinCertPinning.swift
+//  Nostur
+//
+//  TOFU (trust-on-first-use) SHA-256 cert fingerprint store for ElectrumX servers.
+//  Backed by UserDefaults. In-process mutations are serialized by the caller.
+//
+
+import CryptoKit
+import Foundation
+
+enum NamecoinCertPinning {
+    private static let udKey = "nostur.namecoin.pinnedCerts"
+
+    /// Compute SHA-256 fingerprint of the DER-encoded certificate, hex lowercase.
+    static func fingerprint(der: Data) -> String {
+        let hash = SHA256.hash(data: der)
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Load all pinned fingerprints: host:port → SHA256 hex.
+    static func loadAll() -> [String: String] {
+        guard let dict = UserDefaults.standard.dictionary(forKey: udKey) as? [String: String] else {
+            return [:]
+        }
+        return dict
+    }
+
+    static func pinned(for server: ElectrumXServer) -> String? {
+        let key = "\(server.host):\(server.port)"
+        return loadAll()[key]
+    }
+
+    /// Store a fingerprint (first-use). No-op if already stored.
+    static func pinIfMissing(server: ElectrumXServer, fingerprint: String) {
+        let key = "\(server.host):\(server.port)"
+        var all = loadAll()
+        if all[key] == nil {
+            all[key] = fingerprint
+            UserDefaults.standard.set(all, forKey: udKey)
+            #if DEBUG
+            print("[Namecoin] TOFU pinned cert for \(key): \(fingerprint.prefix(16))…")
+            #endif
+        }
+    }
+
+    /// Force-replace the pinned fingerprint (user action from settings).
+    static func repin(server: ElectrumXServer, fingerprint: String) {
+        let key = "\(server.host):\(server.port)"
+        var all = loadAll()
+        all[key] = fingerprint
+        UserDefaults.standard.set(all, forKey: udKey)
+    }
+
+    static func clear(server: ElectrumXServer) {
+        let key = "\(server.host):\(server.port)"
+        var all = loadAll()
+        all.removeValue(forKey: key)
+        UserDefaults.standard.set(all, forKey: udKey)
+    }
+}

--- a/Nostur/Nostr/Namecoin/NamecoinErrorBanner.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinErrorBanner.swift
@@ -1,0 +1,62 @@
+//
+//  NamecoinErrorBanner.swift
+//  Nostur
+//
+//  Inline banner shown in the Search screen when a .bit / Namecoin
+//  identifier lookup fails. Keeps the user informed about what went
+//  wrong (name not found, servers unreachable, no nostr field, etc.)
+//  instead of just silently showing an empty result list.
+//
+
+import SwiftUI
+
+struct NamecoinErrorBanner: View {
+    @Environment(\.theme) private var theme
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+                .font(.title3)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Namecoin lookup failed")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.orange.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+                )
+        )
+    }
+}
+
+/// Produce a short, user-facing sentence for a failed Namecoin outcome.
+/// Success outcomes must be handled by the caller before this is called.
+func namecoinErrorMessage(for outcome: NamecoinResolveOutcome, identifier: String) -> String? {
+    switch outcome {
+    case .success:
+        return nil
+    case .nameNotFound(let name):
+        return "\"\(identifier)\" is not registered on Namecoin (queried \(name))."
+    case .noNostrField(let name):
+        return "\"\(identifier)\" is registered (\(name)) but has no \"nostr\" field in its Namecoin record."
+    case .serversUnreachable(let msg):
+        return "Could not reach any ElectrumX server. \(msg)"
+    case .invalidIdentifier(let id):
+        return "\"\(id)\" is not a valid .bit / d/ / id/ identifier."
+    case .timeout:
+        return "Namecoin lookup timed out. Check your connection and try again."
+    }
+}

--- a/Nostur/Nostr/Namecoin/NamecoinResolver.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinResolver.swift
@@ -1,0 +1,252 @@
+//
+//  NamecoinResolver.swift
+//  Nostur
+//
+//  Parses user input, performs the ElectrumX lookup, and extracts a Nostr
+//  pubkey from the Namecoin name value. Mirrors the behaviour of
+//  `NamecoinNameResolver.kt` in amethyst's quartz/commonMain.
+//
+
+import Foundation
+
+public final class NamecoinResolver: @unchecked Sendable {
+    private let client: IElectrumXClient
+    private let lookupTimeoutNs: UInt64
+    private let serverListProvider: () -> [ElectrumXServer]
+
+    public init(
+        client: IElectrumXClient,
+        lookupTimeoutSeconds: TimeInterval = 20,
+        serverListProvider: @escaping () -> [ElectrumXServer] = { DEFAULT_ELECTRUMX_SERVERS }
+    ) {
+        self.client = client
+        self.lookupTimeoutNs = UInt64(lookupTimeoutSeconds * 1_000_000_000)
+        self.serverListProvider = serverListProvider
+    }
+
+    // MARK: - Public
+
+    /// Return true if the identifier should be routed through Namecoin
+    /// rather than the standard HTTP NIP-05 flow.
+    public static func isNamecoinIdentifier(_ identifier: String) -> Bool {
+        let n = identifier.trimmingCharacters(in: .whitespaces).lowercased()
+        return n.hasSuffix(".bit") || n.hasPrefix("d/") || n.hasPrefix("id/")
+    }
+
+    /// Simple resolver — returns nil if anything goes wrong.
+    public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
+        guard let parsed = Self.parseIdentifier(identifier) else { return nil }
+        return await withTimeout(ns: lookupTimeoutNs) {
+            try? await self.performLookup(parsed: parsed)
+        } ?? nil
+    }
+
+    /// Detailed resolver — returns a specific outcome for UI reporting.
+    public func resolveDetailed(_ identifier: String) async -> NamecoinResolveOutcome {
+        guard let parsed = Self.parseIdentifier(identifier) else {
+            return .invalidIdentifier(identifier)
+        }
+        let outcome: NamecoinResolveOutcome? = await withTimeout(ns: lookupTimeoutNs) {
+            await self.performLookupDetailed(parsed: parsed)
+        }
+        return outcome ?? .timeout
+    }
+
+    // MARK: - Identifier parsing
+
+    enum Namespace { case domain, identity }
+    struct ParsedIdentifier {
+        /// Namecoin name to query, e.g. "d/testls" or "id/alice".
+        let namecoinName: String
+        /// Local-part to extract; "_" for root.
+        let localPart: String
+        let namespace: Namespace
+    }
+
+    static func parseIdentifier(_ raw: String) -> ParsedIdentifier? {
+        let input = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = input.lowercased()
+
+        if lower.hasPrefix("d/") {
+            return ParsedIdentifier(namecoinName: lower, localPart: "_", namespace: .domain)
+        }
+        if lower.hasPrefix("id/") {
+            return ParsedIdentifier(namecoinName: lower, localPart: "_", namespace: .identity)
+        }
+
+        // user@domain.bit
+        if input.contains("@"), lower.hasSuffix(".bit") {
+            let parts = input.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            let localPart: String = {
+                let l = String(parts[0]).lowercased()
+                return l.isEmpty ? "_" : l
+            }()
+            let domain = String(parts[1]).lowercased()
+            guard domain.hasSuffix(".bit") else { return nil }
+            let bare = String(domain.dropLast(4))
+            guard !bare.isEmpty else { return nil }
+            return ParsedIdentifier(namecoinName: "d/\(bare)", localPart: localPart, namespace: .domain)
+        }
+
+        // domain.bit
+        if lower.hasSuffix(".bit") {
+            let bare = String(lower.dropLast(4))
+            guard !bare.isEmpty else { return nil }
+            return ParsedIdentifier(namecoinName: "d/\(bare)", localPart: "_", namespace: .domain)
+        }
+
+        return nil
+    }
+
+    // MARK: - Lookup
+
+    private func performLookup(parsed: ParsedIdentifier) async throws -> NamecoinNostrResult? {
+        let result = try await client.nameShowWithFallback(
+            identifier: parsed.namecoinName,
+            servers: serverListProvider()
+        )
+        guard let result = result else { return nil }
+        guard let json = Self.tryParseJSON(result.value) else { return nil }
+        switch parsed.namespace {
+        case .domain: return Self.extractFromDomainValue(json: json, parsed: parsed)
+        case .identity: return Self.extractFromIdentityValue(json: json, parsed: parsed)
+        }
+    }
+
+    private func performLookupDetailed(parsed: ParsedIdentifier) async -> NamecoinResolveOutcome {
+        let result: NameShowResult?
+        do {
+            result = try await client.nameShowWithFallback(
+                identifier: parsed.namecoinName,
+                servers: serverListProvider()
+            )
+        } catch NamecoinLookupError.nameNotFound {
+            return .nameNotFound(name: parsed.namecoinName)
+        } catch NamecoinLookupError.nameExpired {
+            return .nameNotFound(name: parsed.namecoinName)
+        } catch let NamecoinLookupError.serversUnreachable(msg) {
+            return .serversUnreachable(message: msg)
+        } catch {
+            return .serversUnreachable(message: "\(error)")
+        }
+
+        guard let result = result else {
+            return .nameNotFound(name: parsed.namecoinName)
+        }
+        guard let json = Self.tryParseJSON(result.value) else {
+            return .noNostrField(name: parsed.namecoinName)
+        }
+        let nostr: NamecoinNostrResult?
+        switch parsed.namespace {
+        case .domain: nostr = Self.extractFromDomainValue(json: json, parsed: parsed)
+        case .identity: nostr = Self.extractFromIdentityValue(json: json, parsed: parsed)
+        }
+        if let nostr = nostr {
+            return .success(nostr)
+        }
+        return .noNostrField(name: parsed.namecoinName)
+    }
+
+    // MARK: - Value extraction
+
+    private static let hexRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: "^[0-9a-fA-F]{64}$", options: [])
+    }()
+
+    private static func isValidPubkey(_ s: String) -> Bool {
+        let range = NSRange(location: 0, length: s.utf16.count)
+        return hexRegex.firstMatch(in: s, options: [], range: range) != nil
+    }
+
+    private static func tryParseJSON(_ raw: String) -> [String: Any]? {
+        guard let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+
+    private static func extractFromDomainValue(json: [String: Any], parsed: ParsedIdentifier) -> NamecoinNostrResult? {
+        guard let nostrField = json["nostr"] else { return nil }
+
+        // Simple form: "nostr": "hex"
+        if let hex = nostrField as? String {
+            guard parsed.localPart == "_", isValidPubkey(hex) else { return nil }
+            return NamecoinNostrResult(pubkey: hex.lowercased(), namecoinName: parsed.namecoinName, localPart: "_")
+        }
+
+        // Extended form: "nostr": { "names": {...}, "relays": {...} }
+        guard let nostrObj = nostrField as? [String: Any] else { return nil }
+        guard let names = nostrObj["names"] as? [String: Any] else { return nil }
+
+        var resolvedLocal: String?
+        var pubkey: String?
+
+        if let exact = names[parsed.localPart] as? String, isValidPubkey(exact) {
+            resolvedLocal = parsed.localPart
+            pubkey = exact
+        } else if let root = names["_"] as? String, isValidPubkey(root) {
+            resolvedLocal = "_"
+            pubkey = root
+        } else if parsed.localPart == "_",
+                  let (k, v) = names.first,
+                  let s = v as? String,
+                  isValidPubkey(s) {
+            resolvedLocal = k
+            pubkey = s
+        }
+        guard let rl = resolvedLocal, let pk = pubkey else { return nil }
+        let relays = extractRelays(nostrObj: nostrObj, pubkey: pk)
+        return NamecoinNostrResult(pubkey: pk.lowercased(), relays: relays, namecoinName: parsed.namecoinName, localPart: rl)
+    }
+
+    private static func extractFromIdentityValue(json: [String: Any], parsed: ParsedIdentifier) -> NamecoinNostrResult? {
+        guard let nostrField = json["nostr"] else { return nil }
+
+        if let hex = nostrField as? String, isValidPubkey(hex) {
+            return NamecoinNostrResult(pubkey: hex.lowercased(), namecoinName: parsed.namecoinName)
+        }
+
+        guard let nostrObj = nostrField as? [String: Any] else { return nil }
+
+        if let pk = nostrObj["pubkey"] as? String, isValidPubkey(pk) {
+            let relays = (nostrObj["relays"] as? [String]) ?? []
+            return NamecoinNostrResult(pubkey: pk.lowercased(), relays: relays, namecoinName: parsed.namecoinName)
+        }
+
+        if let names = nostrObj["names"] as? [String: Any],
+           let root = names["_"] as? String,
+           isValidPubkey(root) {
+            let relays = extractRelays(nostrObj: nostrObj, pubkey: root)
+            return NamecoinNostrResult(pubkey: root.lowercased(), relays: relays, namecoinName: parsed.namecoinName)
+        }
+        return nil
+    }
+
+    private static func extractRelays(nostrObj: [String: Any], pubkey: String) -> [String] {
+        guard let relaysMap = nostrObj["relays"] as? [String: Any] else { return [] }
+        if let arr = (relaysMap[pubkey.lowercased()] as? [String]) ?? (relaysMap[pubkey] as? [String]) {
+            return arr
+        }
+        return []
+    }
+}
+
+// MARK: - Timeout helper
+
+/// Wrap an async operation with a timeout. Returns nil on timeout.
+func withTimeout<T: Sendable>(ns: UInt64, _ op: @Sendable @escaping () async -> T?) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask {
+            await op()
+        }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: ns)
+            return nil
+        }
+        let first = await group.next()
+        group.cancelAll()
+        return first ?? nil
+    }
+}

--- a/Nostur/Nostr/Namecoin/NamecoinResolver.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinResolver.swift
@@ -36,18 +36,18 @@ public final class NamecoinResolver: @unchecked Sendable {
     /// Simple resolver — returns nil if anything goes wrong.
     public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
         guard let parsed = Self.parseIdentifier(identifier) else {
-            NSLog("[Namecoin] Resolver.resolve parseIdentifier=nil for %{public}@", identifier)
+            NSLog("%@", "[Namecoin] Resolver.resolve parseIdentifier=nil for \(identifier)")
             return nil
         }
-        NSLog("[Namecoin] Resolver.resolve parsed name=%{public}@ localPart=%{public}@", parsed.namecoinName, parsed.localPart)
+        NSLog("%@", "[Namecoin] Resolver.resolve parsed name=\(parsed.namecoinName) localPart=\(parsed.localPart)")
         let r = await withTimeout(ns: lookupTimeoutNs) {
             do { return try await self.performLookup(parsed: parsed) }
             catch {
-                NSLog("[Namecoin] Resolver.performLookup threw: %{public}@", String(describing: error))
+                NSLog("%@", "[Namecoin] Resolver.performLookup threw: \(error)")
                 return nil
             }
         } ?? nil
-        NSLog("[Namecoin] Resolver.resolve returning %{public}@", r.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")
+        NSLog("%@", "[Namecoin] Resolver.resolve returning \(r.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")")
         return r
     }
 
@@ -117,12 +117,12 @@ public final class NamecoinResolver: @unchecked Sendable {
             servers: serverListProvider()
         )
         guard let result = result else {
-            NSLog("[Namecoin] performLookup got nil NameShowResult for %{public}@", parsed.namecoinName)
+            NSLog("%@", "[Namecoin] performLookup got nil NameShowResult for \(parsed.namecoinName)")
             return nil
         }
-        NSLog("[Namecoin] performLookup got NameShowResult name=%{public}@ value.len=%d", result.name, result.value.count)
+        NSLog("%@", "[Namecoin] performLookup got NameShowResult name=\(result.name) value.len=\(result.value.count)")
         guard let json = Self.tryParseJSON(result.value) else {
-            NSLog("[Namecoin] performLookup JSON parse failed, raw[:200]=%{public}@", String(result.value.prefix(200)))
+            NSLog("%@", "[Namecoin] performLookup JSON parse failed, raw[:200]=\(String(result.value.prefix(200)))")
             return nil
         }
         let extracted: NamecoinNostrResult?
@@ -130,9 +130,7 @@ public final class NamecoinResolver: @unchecked Sendable {
         case .domain: extracted = Self.extractFromDomainValue(json: json, parsed: parsed)
         case .identity: extracted = Self.extractFromIdentityValue(json: json, parsed: parsed)
         }
-        NSLog("[Namecoin] performLookup extract namespace=%{public}@ -> %{public}@",
-              parsed.namespace == .domain ? "domain" : "identity",
-              extracted.map { "pubkey=\($0.pubkey.prefix(16))… localPart=\($0.localPart)" } ?? "nil")
+        NSLog("%@", "[Namecoin] performLookup extract namespace=\(parsed.namespace == .domain ? "domain" : "identity") -> \(extracted.map { "pubkey=\($0.pubkey.prefix(16))… localPart=\($0.localPart)" } ?? "nil")")
         return extracted
     }
 

--- a/Nostur/Nostr/Namecoin/NamecoinResolver.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinResolver.swift
@@ -35,10 +35,20 @@ public final class NamecoinResolver: @unchecked Sendable {
 
     /// Simple resolver — returns nil if anything goes wrong.
     public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
-        guard let parsed = Self.parseIdentifier(identifier) else { return nil }
-        return await withTimeout(ns: lookupTimeoutNs) {
-            try? await self.performLookup(parsed: parsed)
+        guard let parsed = Self.parseIdentifier(identifier) else {
+            NSLog("[Namecoin] Resolver.resolve parseIdentifier=nil for %{public}@", identifier)
+            return nil
+        }
+        NSLog("[Namecoin] Resolver.resolve parsed name=%{public}@ localPart=%{public}@", parsed.namecoinName, parsed.localPart)
+        let r = await withTimeout(ns: lookupTimeoutNs) {
+            do { return try await self.performLookup(parsed: parsed) }
+            catch {
+                NSLog("[Namecoin] Resolver.performLookup threw: %{public}@", String(describing: error))
+                return nil
+            }
         } ?? nil
+        NSLog("[Namecoin] Resolver.resolve returning %{public}@", r.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")
+        return r
     }
 
     /// Detailed resolver — returns a specific outcome for UI reporting.
@@ -106,12 +116,24 @@ public final class NamecoinResolver: @unchecked Sendable {
             identifier: parsed.namecoinName,
             servers: serverListProvider()
         )
-        guard let result = result else { return nil }
-        guard let json = Self.tryParseJSON(result.value) else { return nil }
-        switch parsed.namespace {
-        case .domain: return Self.extractFromDomainValue(json: json, parsed: parsed)
-        case .identity: return Self.extractFromIdentityValue(json: json, parsed: parsed)
+        guard let result = result else {
+            NSLog("[Namecoin] performLookup got nil NameShowResult for %{public}@", parsed.namecoinName)
+            return nil
         }
+        NSLog("[Namecoin] performLookup got NameShowResult name=%{public}@ value.len=%d", result.name, result.value.count)
+        guard let json = Self.tryParseJSON(result.value) else {
+            NSLog("[Namecoin] performLookup JSON parse failed, raw[:200]=%{public}@", String(result.value.prefix(200)))
+            return nil
+        }
+        let extracted: NamecoinNostrResult?
+        switch parsed.namespace {
+        case .domain: extracted = Self.extractFromDomainValue(json: json, parsed: parsed)
+        case .identity: extracted = Self.extractFromIdentityValue(json: json, parsed: parsed)
+        }
+        NSLog("[Namecoin] performLookup extract namespace=%{public}@ -> %{public}@",
+              parsed.namespace == .domain ? "domain" : "identity",
+              extracted.map { "pubkey=\($0.pubkey.prefix(16))… localPart=\($0.localPart)" } ?? "nil")
+        return extracted
     }
 
     private func performLookupDetailed(parsed: ParsedIdentifier) async -> NamecoinResolveOutcome {

--- a/Nostur/Nostr/Namecoin/NamecoinService.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinService.swift
@@ -26,14 +26,14 @@ public actor NamecoinService {
     /// Resolve a .bit identifier, using the cache when available.
     /// Returns nil if the name doesn't exist or can't be resolved.
     public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
-        NSLog("[Namecoin] Service.resolve enter identifier=%{public}@", identifier)
+        NSLog("%@", "[Namecoin] Service.resolve enter identifier=\(identifier)")
         if let cached = await cache.get(identifier) {
-            NSLog("[Namecoin] Service.resolve cache HIT identifier=%{public}@ hasResult=%d", identifier, cached.result != nil ? 1 : 0)
+            NSLog("%@", "[Namecoin] Service.resolve cache HIT identifier=\(identifier) hasResult=\(cached.result != nil ? 1 : 0)")
             return cached.result
         }
-        NSLog("[Namecoin] Service.resolve cache MISS -> resolver.resolve")
+        NSLog("%@", "[Namecoin] Service.resolve cache MISS -> resolver.resolve")
         let result = await resolver.resolve(identifier)
-        NSLog("[Namecoin] Service.resolve resolver returned %{public}@", result.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")
+        NSLog("%@", "[Namecoin] Service.resolve resolver returned \(result.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")")
         await cache.put(identifier, result: result)
         return result
     }

--- a/Nostur/Nostr/Namecoin/NamecoinService.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinService.swift
@@ -1,0 +1,56 @@
+//
+//  NamecoinService.swift
+//  Nostur
+//
+//  Shared singleton: resolver + cache. Provides a simple async API for
+//  callers that don't care about detailed error outcomes.
+//
+
+import Foundation
+
+public actor NamecoinService {
+    public static let shared = NamecoinService()
+
+    private let resolver: NamecoinResolver
+    private let cache: NamecoinCache
+
+    public init(
+        client: IElectrumXClient = ElectrumXClient(),
+        cache: NamecoinCache = NamecoinCache.shared,
+        serverListProvider: @escaping () -> [ElectrumXServer] = { DEFAULT_ELECTRUMX_SERVERS }
+    ) {
+        self.resolver = NamecoinResolver(client: client, serverListProvider: serverListProvider)
+        self.cache = cache
+    }
+
+    /// Resolve a .bit identifier, using the cache when available.
+    /// Returns nil if the name doesn't exist or can't be resolved.
+    public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
+        if let cached = await cache.get(identifier) {
+            return cached.result
+        }
+        let result = await resolver.resolve(identifier)
+        await cache.put(identifier, result: result)
+        return result
+    }
+
+    /// Detailed variant with cache passthrough on success/failure.
+    public func resolveDetailed(_ identifier: String) async -> NamecoinResolveOutcome {
+        if let cached = await cache.get(identifier) {
+            if let result = cached.result {
+                return .success(result)
+            }
+            return .nameNotFound(name: identifier)
+        }
+        let outcome = await resolver.resolveDetailed(identifier)
+        switch outcome {
+        case .success(let r):
+            await cache.put(identifier, result: r)
+        case .nameNotFound, .noNostrField:
+            await cache.put(identifier, result: nil)
+        default:
+            break
+        }
+        return outcome
+    }
+}

--- a/Nostur/Nostr/Namecoin/NamecoinService.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinService.swift
@@ -26,10 +26,14 @@ public actor NamecoinService {
     /// Resolve a .bit identifier, using the cache when available.
     /// Returns nil if the name doesn't exist or can't be resolved.
     public func resolve(_ identifier: String) async -> NamecoinNostrResult? {
+        NSLog("[Namecoin] Service.resolve enter identifier=%{public}@", identifier)
         if let cached = await cache.get(identifier) {
+            NSLog("[Namecoin] Service.resolve cache HIT identifier=%{public}@ hasResult=%d", identifier, cached.result != nil ? 1 : 0)
             return cached.result
         }
+        NSLog("[Namecoin] Service.resolve cache MISS -> resolver.resolve")
         let result = await resolver.resolve(identifier)
+        NSLog("[Namecoin] Service.resolve resolver returned %{public}@", result.map { "pubkey=\($0.pubkey.prefix(16))…" } ?? "nil")
         await cache.put(identifier, result: result)
         return result
     }

--- a/Nostur/Nostr/Namecoin/NamecoinTypes.swift
+++ b/Nostur/Nostr/Namecoin/NamecoinTypes.swift
@@ -1,0 +1,86 @@
+//
+//  NamecoinTypes.swift
+//  Nostur
+//
+//  Ported from vitorpamplona/amethyst PR #2199 (feat/ios-namecoin-nip05).
+//  Namecoin (.bit) NIP-05 resolution types.
+//
+
+import Foundation
+
+/// A single ElectrumX server endpoint.
+public struct ElectrumXServer: Hashable, Codable, Sendable {
+    public let host: String
+    public let port: Int
+    public let useSsl: Bool
+    /// If true, skip system TLS validation (use TOFU cert pinning).
+    /// Required for ElectrumX servers that use self-signed certs,
+    /// which is the norm for the Namecoin ElectrumX ecosystem.
+    public let usePinnedTrustStore: Bool
+
+    public init(host: String, port: Int, useSsl: Bool = true, usePinnedTrustStore: Bool = true) {
+        self.host = host
+        self.port = port
+        self.useSsl = useSsl
+        self.usePinnedTrustStore = usePinnedTrustStore
+    }
+}
+
+/// Result of an ElectrumX `name_show`-equivalent lookup.
+public struct NameShowResult: Sendable {
+    public let name: String
+    public let value: String
+    public let txid: String?
+    public let height: Int?
+}
+
+/// Successful resolution of a Namecoin name to a Nostr identity.
+public struct NamecoinNostrResult: Sendable, Equatable {
+    /// Hex-encoded 32-byte Schnorr public key.
+    public let pubkey: String
+    public let relays: [String]
+    /// The Namecoin name queried, e.g. "d/testls".
+    public let namecoinName: String
+    /// Local-part that matched, e.g. "_" or "alice".
+    public let localPart: String
+
+    public init(pubkey: String, relays: [String] = [], namecoinName: String, localPart: String = "_") {
+        self.pubkey = pubkey
+        self.relays = relays
+        self.namecoinName = namecoinName
+        self.localPart = localPart
+    }
+}
+
+/// Detailed outcome for UI-level error reporting.
+public enum NamecoinResolveOutcome: Sendable {
+    case success(NamecoinNostrResult)
+    case nameNotFound(name: String)
+    case noNostrField(name: String)
+    case serversUnreachable(message: String)
+    case invalidIdentifier(String)
+    case timeout
+}
+
+/// Specific error types for internal signalling.
+public enum NamecoinLookupError: Error, Sendable {
+    case nameNotFound(String)
+    case nameExpired(String)
+    case serversUnreachable(String)
+    case invalidResponse(String)
+    case connectionFailed(String)
+    case timeout
+}
+
+/// Public clearnet Namecoin ElectrumX servers (copied from Amethyst commonMain).
+public let DEFAULT_ELECTRUMX_SERVERS: [ElectrumXServer] = [
+    ElectrumXServer(host: "electrumx.testls.space", port: 50002, useSsl: true, usePinnedTrustStore: true),
+    ElectrumxServerAlias.nmc2,
+    ElectrumxServerAlias.ip187,
+]
+
+// Convenience alias so we can keep all server literals in one place.
+enum ElectrumxServerAlias {
+    static let nmc2 = ElectrumXServer(host: "nmc2.bitcoins.sk", port: 57002, useSsl: true, usePinnedTrustStore: true)
+    static let ip187 = ElectrumXServer(host: "46.229.238.187", port: 57002, useSsl: true, usePinnedTrustStore: true)
+}

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -554,8 +554,10 @@ extension Search {
         }
     }
 
-    /// Resolve a .bit / Namecoin identifier via ElectrumX, then pivot to
-    /// the normal hexId search pipeline so relays get queried for kind:0.
+    /// Resolve a .bit / Namecoin identifier via ElectrumX, then surface the
+    /// pubkey immediately as an NRContact (so the user gets a result row even
+    /// if no relay in their READ pool has kind:0 metadata for that pubkey),
+    /// and kick off a background kind:0 fetch to fill in profile details.
     func namecoinSearch(_ parts: NamecoinParts) {
         NSLog("%@", "[Namecoin] namecoinSearch enter identifier=\(parts.identifier)")
         searching = true
@@ -569,9 +571,59 @@ extension Search {
                 return
             }
             NSLog("%@", "[Namecoin] namecoinSearch resolved \(identifier) -> \(String(result.pubkey.prefix(16)))")
-            await MainActor.run {
-                self.hexIdSearch(result.pubkey)
+
+            // Step 1: show a contact row for the resolved pubkey immediately.
+            // NRContact.instance(...) creates a placeholder if no metadata exists yet;
+            // when kind:0 metadata arrives from relays it will be wired into the same
+            // NRContact and the row will update live.
+            let pubkey = result.pubkey
+            let nrContact: NRContact? = await withCheckedContinuation { (cont: CheckedContinuation<NRContact?, Never>) in
+                bg().perform {
+                    let c = NRContact.instance(of: pubkey)
+                    cont.resume(returning: c)
+                }
             }
+            await MainActor.run {
+                if let nrContact {
+                    NSLog("%@", "[Namecoin] namecoinSearch surfacing NRContact for pubkey=\(String(pubkey.prefix(16)))…")
+                    self.contacts = [nrContact]
+                } else {
+                    NSLog("%@", "[Namecoin] namecoinSearch NRContact.instance returned nil (unexpected)")
+                }
+            }
+
+            // Step 2: kick off relay queries for kind:0 metadata. We can't
+            // call hexIdSearch here because it resets `contacts = []` at entry,
+            // which would wipe the placeholder row we just showed. Inline the
+            // REQ dispatch instead; when metadata arrives it's imported into
+            // Core Data + the NRContactCache entry we created above, so the
+            // already-visible NRContact row will update live.
+            await MainActor.run {
+                let searchTask = ReqTask(prefix: "NMC-", reqCommand: { taskId in
+                    NSLog("%@", "[Namecoin] namecoinSearch dispatching REQ taskId=\(taskId) for kind:0 pubkey=\(String(pubkey.prefix(16)))…")
+                    req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .READ)
+                    req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .SEARCH_ONLY)
+                }, processResponseCommand: { taskId, _, _ in
+                    NSLog("%@", "[Namecoin] namecoinSearch relay response for taskId=\(taskId)")
+                    bg().perform {
+                        guard let refreshed = NRContact.fetch(pubkey) else {
+                            NSLog("%@", "[Namecoin] namecoinSearch NRContact.fetch after response: nil")
+                            return
+                        }
+                        Task { @MainActor in
+                            self.contacts = [refreshed]
+                            self.searching = false
+                        }
+                    }
+                })
+                self.backlog.add(searchTask)
+                searchTask.fetch()
+            }
+
+            // Stop the spinner after a short grace period even if no metadata arrives;
+            // the placeholder row is already visible and usable.
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            await MainActor.run { self.searching = false }
         }
     }
     

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -27,9 +27,14 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
         if searchTrimmed.contains(".") {
             let domain = String(searchTrimmed.dropFirst(1))
             let name = "_"
-            
+
+            // Namecoin (.bit) — route to ElectrumX instead of HTTPS
+            if NamecoinResolver.isNamecoinIdentifier(domain) {
+                return .namecoin(NamecoinParts(identifier: domain, domain: domain, name: name))
+            }
+
             let url = URL(string: "https://\(domain)/.well-known/nostr.json?name=\(name)")
-            
+
             return .nip05(Nip05Parts(nip05url: url, domain: domain, name: name))
         }
         return .nametag(String(searchTrimmed.dropFirst(1)))
@@ -48,13 +53,22 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
     }
     else if searchTrimmed.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: true).count == 2 {
         let nip05parts = searchTrimmed.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: true)
-        
+
         let domain = String(nip05parts[1])
         let name = String(nip05parts[0])
-        
+
+        // Namecoin (.bit) — route to ElectrumX instead of HTTPS
+        if NamecoinResolver.isNamecoinIdentifier(domain) {
+            return .namecoin(NamecoinParts(identifier: searchTrimmed, domain: domain, name: name))
+        }
+
         let url = URL(string: "https://\(domain)/.well-known/nostr.json?name=\(name)")
-        
+
         return .nip05(Nip05Parts(nip05url: url, domain: domain, name: name))
+    }
+    // Bare .bit domain or d/*/id/* namespace
+    else if NamecoinResolver.isNamecoinIdentifier(searchTrimmed) {
+        return .namecoin(NamecoinParts(identifier: searchTrimmed, domain: searchTrimmed, name: "_"))
     }
     
     
@@ -71,8 +85,15 @@ public enum TypeOfSearch {
     case note1(String)
     case hexId(String)
     case nip05(Nip05Parts)
+    case namecoin(NamecoinParts)
     case url(String)
     case other(String)
+}
+
+public struct NamecoinParts {
+    let identifier: String // full user input (e.g. "alice@example.bit" or "example.bit")
+    let domain: String
+    let name: String
 }
 
 public struct Nip05Parts {
@@ -507,6 +528,24 @@ extension Search {
             guard let pubkey = nostrJson.names[nip05parts.name], !pubkey.isEmpty else { return }
             
             hexIdSearch(pubkey)
+        }
+    }
+
+    /// Resolve a .bit / Namecoin identifier via ElectrumX, then pivot to
+    /// the normal hexId search pipeline so relays get queried for kind:0.
+    func namecoinSearch(_ parts: NamecoinParts) {
+        searching = true
+        contacts = []
+        nrPosts = []
+        let identifier = parts.identifier
+        Task {
+            guard let result = await NamecoinService.shared.resolve(identifier) else {
+                await MainActor.run { self.searching = false }
+                return
+            }
+            await MainActor.run {
+                self.hexIdSearch(result.pubkey)
+            }
         }
     }
     

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -68,6 +68,7 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
     }
     // Bare .bit domain or d/*/id/* namespace
     else if NamecoinResolver.isNamecoinIdentifier(searchTrimmed) {
+        NSLog("[Namecoin] typeOfSearch routing to .namecoin for %{public}@", searchTrimmed)
         return .namecoin(NamecoinParts(identifier: searchTrimmed, domain: searchTrimmed, name: "_"))
     }
     
@@ -534,15 +535,18 @@ extension Search {
     /// Resolve a .bit / Namecoin identifier via ElectrumX, then pivot to
     /// the normal hexId search pipeline so relays get queried for kind:0.
     func namecoinSearch(_ parts: NamecoinParts) {
+        NSLog("[Namecoin] namecoinSearch enter identifier=%{public}@", parts.identifier)
         searching = true
         contacts = []
         nrPosts = []
         let identifier = parts.identifier
         Task {
             guard let result = await NamecoinService.shared.resolve(identifier) else {
+                NSLog("[Namecoin] namecoinSearch resolve returned nil for %{public}@", identifier)
                 await MainActor.run { self.searching = false }
                 return
             }
+            NSLog("[Namecoin] namecoinSearch resolved %{public}@ -> %{public}@", identifier, String(result.pubkey.prefix(16)))
             await MainActor.run {
                 self.hexIdSearch(result.pubkey)
             }

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -558,73 +558,84 @@ extension Search {
     /// pubkey immediately as an NRContact (so the user gets a result row even
     /// if no relay in their READ pool has kind:0 metadata for that pubkey),
     /// and kick off a background kind:0 fetch to fill in profile details.
+    /// On failure, sets `namecoinError` with a user-facing message that is
+    /// shown as a banner above the results.
     func namecoinSearch(_ parts: NamecoinParts) {
         NSLog("%@", "[Namecoin] namecoinSearch enter identifier=\(parts.identifier)")
         searching = true
         contacts = []
         nrPosts = []
+        namecoinError = nil
         let identifier = parts.identifier
+        let searchAtStart = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         Task {
-            guard let result = await NamecoinService.shared.resolve(identifier) else {
-                NSLog("%@", "[Namecoin] namecoinSearch resolve returned nil for \(identifier)")
-                await MainActor.run { self.searching = false }
+            let outcome = await NamecoinService.shared.resolveDetailed(identifier)
+
+            // Guard against stale results: if the user has changed the input
+            // since this lookup started, a newer onChange has already reset the
+            // UI state; don't overwrite it with this result.
+            let currentInput = await MainActor.run { self.searchText.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard currentInput == searchAtStart else {
+                NSLog("%@", "[Namecoin] namecoinSearch stale result (started with \(searchAtStart), current=\(currentInput)); discarding")
                 return
             }
-            NSLog("%@", "[Namecoin] namecoinSearch resolved \(identifier) -> \(String(result.pubkey.prefix(16)))")
 
-            // Step 1: show a contact row for the resolved pubkey immediately.
-            // NRContact.instance(...) creates a placeholder if no metadata exists yet;
-            // when kind:0 metadata arrives from relays it will be wired into the same
-            // NRContact and the row will update live.
-            let pubkey = result.pubkey
-            let nrContact: NRContact? = await withCheckedContinuation { (cont: CheckedContinuation<NRContact?, Never>) in
-                bg().perform {
-                    let c = NRContact.instance(of: pubkey)
-                    cont.resume(returning: c)
+            switch outcome {
+            case .success(let result):
+                NSLog("%@", "[Namecoin] namecoinSearch resolved \(identifier) -> \(String(result.pubkey.prefix(16)))")
+                await self.surfaceResolvedPubkey(result.pubkey)
+            case .nameNotFound, .noNostrField, .serversUnreachable, .invalidIdentifier, .timeout:
+                let msg = namecoinErrorMessage(for: outcome, identifier: identifier) ?? "Unknown error."
+                NSLog("%@", "[Namecoin] namecoinSearch FAILED \(identifier): \(msg)")
+                await MainActor.run {
+                    self.namecoinError = msg
+                    self.searching = false
                 }
             }
-            await MainActor.run {
-                if let nrContact {
-                    NSLog("%@", "[Namecoin] namecoinSearch surfacing NRContact for pubkey=\(String(pubkey.prefix(16)))…")
-                    self.contacts = [nrContact]
-                } else {
-                    NSLog("%@", "[Namecoin] namecoinSearch NRContact.instance returned nil (unexpected)")
-                }
-            }
-
-            // Step 2: kick off relay queries for kind:0 metadata. We can't
-            // call hexIdSearch here because it resets `contacts = []` at entry,
-            // which would wipe the placeholder row we just showed. Inline the
-            // REQ dispatch instead; when metadata arrives it's imported into
-            // Core Data + the NRContactCache entry we created above, so the
-            // already-visible NRContact row will update live.
-            await MainActor.run {
-                let searchTask = ReqTask(prefix: "NMC-", reqCommand: { taskId in
-                    NSLog("%@", "[Namecoin] namecoinSearch dispatching REQ taskId=\(taskId) for kind:0 pubkey=\(String(pubkey.prefix(16)))…")
-                    req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .READ)
-                    req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .SEARCH_ONLY)
-                }, processResponseCommand: { taskId, _, _ in
-                    NSLog("%@", "[Namecoin] namecoinSearch relay response for taskId=\(taskId)")
-                    bg().perform {
-                        guard let refreshed = NRContact.fetch(pubkey) else {
-                            NSLog("%@", "[Namecoin] namecoinSearch NRContact.fetch after response: nil")
-                            return
-                        }
-                        Task { @MainActor in
-                            self.contacts = [refreshed]
-                            self.searching = false
-                        }
-                    }
-                })
-                self.backlog.add(searchTask)
-                searchTask.fetch()
-            }
-
-            // Stop the spinner after a short grace period even if no metadata arrives;
-            // the placeholder row is already visible and usable.
-            try? await Task.sleep(nanoseconds: 4_000_000_000)
-            await MainActor.run { self.searching = false }
         }
+    }
+
+    /// Show the resolved pubkey in the results immediately (via a placeholder
+    /// NRContact) and fire a kind:0 REQ to READ+SEARCH_ONLY relays so the
+    /// profile fields fill in live when metadata arrives.
+    private func surfaceResolvedPubkey(_ pubkey: String) async {
+        let nrContact: NRContact? = await withCheckedContinuation { (cont: CheckedContinuation<NRContact?, Never>) in
+            bg().perform {
+                let c = NRContact.instance(of: pubkey)
+                cont.resume(returning: c)
+            }
+        }
+        await MainActor.run {
+            if let nrContact {
+                NSLog("%@", "[Namecoin] namecoinSearch surfacing NRContact for pubkey=\(String(pubkey.prefix(16)))…")
+                self.contacts = [nrContact]
+            }
+        }
+
+        await MainActor.run {
+            let searchTask = ReqTask(prefix: "NMC-", reqCommand: { taskId in
+                NSLog("%@", "[Namecoin] namecoinSearch dispatching REQ taskId=\(taskId) for kind:0 pubkey=\(String(pubkey.prefix(16)))…")
+                req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .READ)
+                req(RM.getUserMetadata(pubkey: pubkey, subscriptionId: taskId), relayType: .SEARCH_ONLY)
+            }, processResponseCommand: { taskId, _, _ in
+                NSLog("%@", "[Namecoin] namecoinSearch relay response for taskId=\(taskId)")
+                bg().perform {
+                    guard let refreshed = NRContact.fetch(pubkey) else {
+                        NSLog("%@", "[Namecoin] namecoinSearch NRContact.fetch after response: nil")
+                        return
+                    }
+                    Task { @MainActor in
+                        self.contacts = [refreshed]
+                        self.searching = false
+                    }
+                }
+            })
+            self.backlog.add(searchTask)
+            searchTask.fetch()
+        }
+
+        try? await Task.sleep(nanoseconds: 4_000_000_000)
+        await MainActor.run { self.searching = false }
     }
     
     func urlSearch(_ term: String) {

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -449,8 +449,13 @@ extension Search {
     }
     
     func hexIdSearch(_ term: String) {
+        NSLog("%@", "[Namecoin] hexIdSearch enter term=\(term.prefix(16))… len=\(term.count)")
         guard NostrRegexes.default.matchingStrings(term, regex: NostrRegexes.default.cache[.hexId]!).count == 1
-        else { return }
+        else {
+            NSLog("%@", "[Namecoin] hexIdSearch regex FAILED for term=\(term.prefix(16))…")
+            return
+        }
+        NSLog("%@", "[Namecoin] hexIdSearch regex ok, dispatching local + relay queries")
         
         searching = true
         contacts = []
@@ -459,7 +464,11 @@ extension Search {
         let bgContext = bg()
         
         bgContext.perform {
-            guard let event = Event.fetchEvent(id: term, context: bgContext) else { return }
+            guard let event = Event.fetchEvent(id: term, context: bgContext) else {
+                NSLog("%@", "[Namecoin] hexIdSearch local Event.fetchEvent: not found")
+                return
+            }
+            NSLog("%@", "[Namecoin] hexIdSearch local Event.fetchEvent: FOUND")
             let nrPost = NRPost(event: event)
             Task { @MainActor in
                 self.nrPosts = [nrPost]
@@ -468,7 +477,11 @@ extension Search {
         }
         
         bg().perform {
-            guard let nrContact = NRContact.fetch(term) else { return }
+            guard let nrContact = NRContact.fetch(term) else {
+                NSLog("%@", "[Namecoin] hexIdSearch local NRContact.fetch: not found")
+                return
+            }
+            NSLog("%@", "[Namecoin] hexIdSearch local NRContact.fetch: FOUND")
             Task { @MainActor in
                 self.contacts = [nrContact]
                 searching = false
@@ -476,14 +489,17 @@ extension Search {
         }
         
         let searchTask1 = ReqTask(prefix: "SEA-", reqCommand: { taskId in
+            NSLog("%@", "[Namecoin] hexIdSearch dispatching REQ taskId=\(taskId) to READ+SEARCH_ONLY relays")
             req(RM.getEvent(id: term, subscriptionId: taskId), relayType: .READ)
             req(RM.getEvent(id: term, subscriptionId: taskId), relayType: .SEARCH_ONLY)
             
             req(RM.getUserMetadata(pubkey: term, subscriptionId: taskId), relayType: .READ)
             req(RM.getUserMetadata(pubkey: term, subscriptionId: taskId), relayType: .SEARCH_ONLY)
         }, processResponseCommand: { taskId, _, _ in
+            NSLog("%@", "[Namecoin] hexIdSearch response received for taskId=\(taskId)")
             bg().perform {
                 guard let event = Event.fetchEvent(id: term, context: bg()) else { return }
+                NSLog("%@", "[Namecoin] hexIdSearch response: Event.fetchEvent FOUND")
                 let nrPost = NRPost(event: event)
                 Task { @MainActor in
                     self.nrPosts = [nrPost]
@@ -491,7 +507,11 @@ extension Search {
                 }
             }
             bg().perform {
-                guard let nrContact = NRContact.fetch(term) else { return }
+                guard let nrContact = NRContact.fetch(term) else {
+                    NSLog("%@", "[Namecoin] hexIdSearch response: NRContact.fetch still nil")
+                    return
+                }
+                NSLog("%@", "[Namecoin] hexIdSearch response: NRContact.fetch FOUND -> setting contacts")
                 Task { @MainActor in
                     self.contacts = [nrContact]
                     searching = false

--- a/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
+++ b/Nostur/Screens/MainTabs/Search/Search+Helpers.swift
@@ -30,6 +30,7 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
 
             // Namecoin (.bit) — route to ElectrumX instead of HTTPS
             if NamecoinResolver.isNamecoinIdentifier(domain) {
+                NSLog("%@", "[Namecoin] typeOfSearch routing to .namecoin for @\(domain) (bare @domain form)")
                 return .namecoin(NamecoinParts(identifier: domain, domain: domain, name: name))
             }
 
@@ -59,6 +60,7 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
 
         // Namecoin (.bit) — route to ElectrumX instead of HTTPS
         if NamecoinResolver.isNamecoinIdentifier(domain) {
+            NSLog("%@", "[Namecoin] typeOfSearch routing to .namecoin for \(searchTrimmed) (user@domain form, name=\(name) domain=\(domain))")
             return .namecoin(NamecoinParts(identifier: searchTrimmed, domain: domain, name: name))
         }
 
@@ -68,7 +70,7 @@ func typeOfSearch(_ searchInput: String) -> TypeOfSearch {
     }
     // Bare .bit domain or d/*/id/* namespace
     else if NamecoinResolver.isNamecoinIdentifier(searchTrimmed) {
-        NSLog("[Namecoin] typeOfSearch routing to .namecoin for %{public}@", searchTrimmed)
+        NSLog("%@", "[Namecoin] typeOfSearch routing to .namecoin for \(searchTrimmed)")
         return .namecoin(NamecoinParts(identifier: searchTrimmed, domain: searchTrimmed, name: "_"))
     }
     
@@ -535,18 +537,18 @@ extension Search {
     /// Resolve a .bit / Namecoin identifier via ElectrumX, then pivot to
     /// the normal hexId search pipeline so relays get queried for kind:0.
     func namecoinSearch(_ parts: NamecoinParts) {
-        NSLog("[Namecoin] namecoinSearch enter identifier=%{public}@", parts.identifier)
+        NSLog("%@", "[Namecoin] namecoinSearch enter identifier=\(parts.identifier)")
         searching = true
         contacts = []
         nrPosts = []
         let identifier = parts.identifier
         Task {
             guard let result = await NamecoinService.shared.resolve(identifier) else {
-                NSLog("[Namecoin] namecoinSearch resolve returned nil for %{public}@", identifier)
+                NSLog("%@", "[Namecoin] namecoinSearch resolve returned nil for \(identifier)")
                 await MainActor.run { self.searching = false }
                 return
             }
-            NSLog("[Namecoin] namecoinSearch resolved %{public}@ -> %{public}@", identifier, String(result.pubkey.prefix(16)))
+            NSLog("%@", "[Namecoin] namecoinSearch resolved \(identifier) -> \(String(result.pubkey.prefix(16)))")
             await MainActor.run {
                 self.hexIdSearch(result.pubkey)
             }

--- a/Nostur/Screens/MainTabs/Search/Search.swift
+++ b/Nostur/Screens/MainTabs/Search/Search.swift
@@ -169,6 +169,8 @@ struct Search: View {
                     hexIdSearch(term)
                 case .nip05(let nip05parts):
                     nip05Search(nip05parts)
+                case .namecoin(let parts):
+                    namecoinSearch(parts)
                 case .url(let term):
                     urlSearch(term)
                 case .other(let term):

--- a/Nostur/Screens/MainTabs/Search/Search.swift
+++ b/Nostur/Screens/MainTabs/Search/Search.swift
@@ -18,9 +18,13 @@ struct Search: View {
     @State var nrPosts: [NRPost] = []
     @State var contacts: [NRContact] = []
     @State var searching = false
+    /// User-facing error message set by `namecoinSearch` when a .bit lookup
+    /// fails. Shown as a banner above the results. Cleared on every new
+    /// search input.
+    @State var namecoinError: String? = nil
     @State private var navPath = NBNavigationPath()
 
-    @State private var searchText = ""
+    @State var searchText = ""
     @State var searchTask: Task<Void, Never>? = nil
     @State var backlog = Backlog(timeout: 12, backlogDebugName: "Search")
     @ObservedObject var settings: SettingsStore = .shared
@@ -46,6 +50,10 @@ struct Search: View {
                     ScrollView {
                         if isSearchingHashtag {
                             FollowHashtagTile(hashtag:String(searchText.trimmingCharacters(in: .whitespacesAndNewlines).dropFirst(1)), account:la.account)
+                                .padding([.top, .horizontal], 10)
+                        }
+                        if let namecoinError {
+                            NamecoinErrorBanner(message: namecoinError)
                                 .padding([.top, .horizontal], 10)
                         }
                         if (contacts.isEmpty && nrPosts.isEmpty && searching) {
@@ -148,6 +156,7 @@ struct Search: View {
             .onChange(of: searchText) { searchInput in
                 nrPosts = []
                 contacts = []
+                namecoinError = nil
 
                 navPath.removeLast(navPath.count)
                 switch typeOfSearch(searchInput) {


### PR DESCRIPTION
## Summary

Adds native Swift support for resolving **Namecoin `.bit` NIP-05 identifiers** alongside the existing HTTP `.well-known/nostr.json` flow. Purely additive — zero change to the behaviour of existing HTTPS NIP-05 verification.

## What works

- Identifiers like `alice@example.bit`, `example.bit`, `@example.bit`, `d/example`, and `id/alice` are detected in **search** and routed through an ElectrumX resolver instead of an HTTPS lookup.
- Resolved pubkeys are surfaced as an `NRContact` row immediately, so the user sees a result even when their READ relays don't have kind:0 metadata for that pubkey. A `kind:0` REQ is still dispatched; if metadata arrives the same `NRContact` (observable) fills in live.
- Failed lookups show a user-facing orange banner in the Search view with a specific message (not registered / no nostr field / servers unreachable / invalid identifier / timeout).
- Background **NIP-05 verifier** also picks up `.bit` identifiers on contact metadata and marks `nip05verifiedAt` when the resolved Namecoin pubkey matches.
- TOFU cert pinning for self-signed ElectrumX certs (the norm for this ecosystem), persisted in `UserDefaults`.
- In-memory LRU cache (24h TTL).

## Verified end-to-end

- `testls.bit` → `460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c` ✅
- `m@testls.bit` → `6cdebccabda1dfa058ab85352a79509b592b2bdfa0370325e28ec1cb4f18667d` ✅

Both match the expected pubkeys for those names on mainnet Namecoin, verified against the same tx out-of-band via Python.

## Why native Network.framework

On iOS, SecureTransport (`SSLCreateContext`) does **not** honour `kSSLSessionOptionBreakOnServerAuth` for self-signed certs — it returns `errSSLPeerUnknownCA` (-9841) before the verify callback fires. `NWConnection` + `NWProtocolTLS.Options` + `sec_protocol_options_set_verify_block` is the only approach that works. This was discovered in [vitorpamplona/amethyst PR #2199](https://github.com/vitorpamplona/amethyst/pull/2199); that PR needed KMP C-interop because K/N can't bridge the Network.framework block types, but native Swift can use them directly.

## Files added

Under `Nostur/Nostr/Namecoin/`:

- `NamecoinTypes.swift` — structs, errors, default server list.
- `ElectrumXClient.swift` — actor-based NWConnection TLS client; 4-RPC flow (`server.version` → `blockchain.scripthash.get_history` → `blockchain.transaction.get` → `blockchain.headers.subscribe`).
- `NamecoinResolver.swift` — identifier parsing + value extraction (simple and extended `nostr` forms).
- `NamecoinCertPinning.swift` — UserDefaults-backed TOFU fingerprint store.
- `NamecoinCache.swift` — actor-based LRU cache (500 entries, 24h TTL).
- `NamecoinService.swift` — singleton wiring (resolve + resolveDetailed).
- `NamecoinErrorBanner.swift` — SwiftUI banner shown on failed lookups.

## Files changed

- `Nostur/Screens/MainTabs/Search/Search+Helpers.swift` — detect `.bit` in `typeOfSearch`; new `namecoinSearch` that resolves, surfaces a placeholder `NRContact` immediately, and runs a kind:0 REQ in parallel.
- `Nostur/Screens/MainTabs/Search/Search.swift` — wire `.namecoin` case; `@State namecoinError` plus banner rendering.
- `Nostur/Nostr/NIP05Verifier.swift` — sidecar path for `.bit` contacts (HTTP pipeline skips them).

## Tested

- Builds cleanly for iPhone 17 Pro Simulator (iOS 26.2 SDK, deployment target iOS 15.5).
- Live resolution verified against `electrumx.testls.space:50002` through the app in the simulator.
- TLS TOFU pinning works on first connect and enforces match on subsequent connects.

## Not yet included (follow-ups)

- Settings UI to add/remove custom ElectrumX servers and view/reset pinned fingerprints (data layer is there, UI is not).
- Passing relay hints from the Namecoin value into the kind:0 REQ dispatch (today most `.bit` names don't include relay hints, but the hook exists).
- Unit tests (needs a mock ElectrumX server or simulator integration).

Reference implementation: [amethyst PR #2199](https://github.com/vitorpamplona/amethyst/pull/2199).
