### PR TITLE
Add LibreTranslate note translations

### DIFF
--- a/Nostur/Post/Kinds/Kind1.swift
+++ b/Nostur/Post/Kinds/Kind1.swift
@@ -105,6 +105,7 @@ struct Kind1: View {
                 ContentRenderer(nrPost: nrPost, showMore: .constant(true), isDetail: isDetail, fullWidth: fullWidth, forceAutoload: forceAutoload)
                     .environment(\.availableWidth, availableWidth_)
                     .frame(maxWidth: .infinity, alignment:.leading)
+                automaticTranslation
             }
             else {
                 
@@ -173,6 +174,7 @@ struct Kind1: View {
 //                        }
 //                        .background(Color.red)
 //                    }
+                automaticTranslation
             }
         }
     }
@@ -212,8 +214,18 @@ struct Kind1: View {
                                 showMore = true
                                 clipBottomHeight = 28000.0
                             })
-                    }
+                        }
                 }
+            automaticTranslation
+        }
+    }
+    
+    @ViewBuilder
+    private var automaticTranslation: some View {
+        if settings.translationAutoTranslate,
+           !nxViewingContext.contains(.screenshot),
+           !nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            PostTranslationInline(nrPost: nrPost)
         }
     }
 }

--- a/Nostur/Post/Kinds/Kind1.swift
+++ b/Nostur/Post/Kinds/Kind1.swift
@@ -12,12 +12,12 @@ struct Kind1: View {
     @Environment(\.theme) private var theme
     @Environment(\.containerID) private var containerID
     @Environment(\.availableWidth) private var availableWidth
-    
+
     @ObservedObject private var settings: SettingsStore = .shared
     private let nrPost: NRPost
     @ObservedObject private var nrContact: NRContact
     @State private var showMore = false
-    
+
     private let hideFooter: Bool // For rendering in NewReply
     private let missingReplyTo: Bool // For rendering in thread
     private var connect: ThreadConnectDirection? = nil // For thread connecting line between profile pics in thread
@@ -27,23 +27,23 @@ struct Kind1: View {
     private let fullWidth: Bool
     private let grouped: Bool
     private let forceAutoload: Bool
-    
+
     private let THREAD_LINE_OFFSET = 24.0
-    
-    
+
+
     private var availableWidth_: CGFloat { // dim.listWidth is now .availableWidth, so now this one is .availableWidth_
         if isDetail || fullWidth || isEmbedded {
             return availableWidth - 20
         }
-        
+
         return DIMENSIONS.availableNoteRowImageWidth(availableWidth)
     }
-    
+
     private var isOlasGeneric: Bool { (nrPost.kind == 1 && (nrPost.kTag ?? "") == "20") }
-    
+
     @State var showMiniProfile = false
     @State var clipBottomHeight: CGFloat = 900.0
-    
+
     init(nrPost: NRPost, hideFooter: Bool = true, missingReplyTo: Bool = false, connect: ThreadConnectDirection? = nil,
          isReply: Bool = false, isDetail: Bool = false, isEmbedded: Bool = false, fullWidth: Bool, grouped: Bool = false,
          forceAutoload: Bool = false) {
@@ -60,7 +60,7 @@ struct Kind1: View {
         self.forceAutoload = forceAutoload
 //        _clipBottomHeight = State(wrappedValue: isEmbedded ? 300.0 : 900.0)
     }
-    
+
     var body: some View {
         if nrPost.plainTextOnly {
             Text("TODO PLAINTEXTONLY") // TODO: PLAIN TEXTO ONLY
@@ -72,11 +72,11 @@ struct Kind1: View {
             self.normalView
         }
     }
-    
+
     private var shouldAutoload: Bool {
         return !nrPost.isNSFW && (forceAutoload || SettingsStore.shouldAutodownload(nrPost) || nxViewingContext.contains(.screenshot))
     }
-    
+
     @ViewBuilder
     private var normalView: some View {
 #if DEBUG
@@ -96,19 +96,19 @@ struct Kind1: View {
                 if availableWidth < 75 { // Probably too many embeds in embeds in embeds in embeds, no space left
                     Image(systemName: "exclamationmark.triangle.fill")
                 }
-                
+
 //                Color.purple
 //                    .frame(height: 30)
 //                    .overlay { Text(availableWidth_.description) }
 //                    .debugDimensions("Kind1.normalView")
-                
+
                 ContentRenderer(nrPost: nrPost, showMore: .constant(true), isDetail: isDetail, fullWidth: fullWidth, forceAutoload: forceAutoload)
                     .environment(\.availableWidth, availableWidth_)
                     .frame(maxWidth: .infinity, alignment:.leading)
                 automaticTranslation
             }
             else {
-                
+
                 if missingReplyTo || nxViewingContext.contains(.screenshot) {
                     ReplyingToFragmentView(nrPost: nrPost)
                 }
@@ -120,12 +120,12 @@ struct Kind1: View {
                 if availableWidth < 75 { // Probably too many embeds in embeds in embeds in embeds, no space left
                     Image(systemName: "exclamationmark.triangle.fill")
                 }
-                
+
 //                Color.purple
 //                    .frame(height: 30)
 //                    .overlay { Text(availableWidth_.description) }
 //                    .debugDimensions("Kind1.normalView2")
-                
+
                 ContentRenderer(nrPost: nrPost, showMore: $showMore, isDetail: isDetail, fullWidth: fullWidth, forceAutoload: forceAutoload)
                     .environment(\.availableWidth, availableWidth_)
 //                    .fixedSize(horizontal: false, vertical: true) // <-- this or child .fixedSizes will try to render outside frame and cutoff (because clipped() below)
@@ -146,7 +146,7 @@ struct Kind1: View {
                                 .highPriorityGesture(TapGesture().onEnded {
                                     showMore = true
                                     clipBottomHeight = 28000.0
-                                })                            
+                                })
                         }
                     }
 //                    .overlay(alignment: .topLeading) {
@@ -157,18 +157,18 @@ struct Kind1: View {
 //                            print("previewWeights.linkPreviews: \(String(describing: nrPost.previewWeights?.linkPreviews))")
 //                            print("previewWeights.text: \(String(describing: nrPost.previewWeights?.text))")
 //                            print("previewWeights.other: \(String(describing: nrPost.previewWeights?.other))")
-//                            
+//
 //                            print("previewWeights.morePosts: \(String(describing: nrPost.previewWeights?.morePosts))")
 //                            print("previewWeights.moreVideos: \(String(describing: nrPost.previewWeights?.moreVideos))")
 //                            print("previewWeights.morePictures: \(String(describing: nrPost.previewWeights?.morePictures))")
 //                            print("previewWeights.linkPreviews: \(String(describing: nrPost.previewWeights?.linkPreviews))")
 //                            print("previewWeights.moreText: \(String(describing: nrPost.previewWeights?.moreText))")
 //                            print("previewWeights.moreOther: \(String(describing: nrPost.previewWeights?.moreOther))")
-//                            
-//                            
+//
+//
 //                            print("previewWeights.morePosts: \(String(describing: nrPost.previewWeights?.morePosts))")
 //                            print("previewWeights.weight: \(String(describing: nrPost.previewWeights?.weight))")
-//                            
+//
 //                            print("nrPost.sizeEstimate.rawValue: \(String(describing: nrPost.sizeEstimate.rawValue))")
 //                            print("previewWeights.textOnly: \(String(describing: nrPost.previewWeights?.textOnly))")
 //                        }
@@ -178,11 +178,11 @@ struct Kind1: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private var embeddedView: some View {
         PostEmbeddedLayout(nrPost: nrPost) {
-            
+
             if missingReplyTo {
                 ReplyingToFragmentView(nrPost: nrPost)
             }
@@ -194,7 +194,7 @@ struct Kind1: View {
             if availableWidth < 75 { // Probably too many embeds in embeds in embeds in embeds, no space left
                 Image(systemName: "exclamationmark.triangle.fill")
             }
-            
+
             ContentRenderer(nrPost: nrPost, showMore: $showMore,  isDetail: false, fullWidth: fullWidth, forceAutoload: shouldAutoload)
                 .environment(\.availableWidth, availableWidth_)
                 .frame(minHeight: nrPost.sizeEstimate.rawValue, maxHeight: clipBottomHeight, alignment: .top)
@@ -219,7 +219,7 @@ struct Kind1: View {
             automaticTranslation
         }
     }
-    
+
     @ViewBuilder
     private var automaticTranslation: some View {
         if settings.translationAutoTranslate,

--- a/Nostur/Post/PostMenu/PostMenu.swift
+++ b/Nostur/Post/PostMenu/PostMenu.swift
@@ -226,6 +226,16 @@ struct PostMenu: View {
             }
             .listRowBackground(theme.background)
             
+            if !nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                NavigationLink {
+                    PostTranslationSheet(nrPost: nrPost, rootDismiss: dismiss)
+                } label: {
+                    Label("Translate", systemImage: "globe")
+                        .foregroundColor(theme.accent)
+                }
+                .listRowBackground(theme.background)
+            }
+            
             Button {
                 dismiss()
                 if let pn = Event.fetchEvent(id: nrPost.id, context: viewContext())?.privateNote {

--- a/Nostur/Post/PostMenu/PostMenu.swift
+++ b/Nostur/Post/PostMenu/PostMenu.swift
@@ -24,23 +24,23 @@ struct PostMenu: View {
     @State private var followToggles = false
     @State private var blockOptions = false
     @State private var pubkeysInPost: Set<String> = []
-    
+
     @State private var showMultiFollowSheet = false
-    
+
     @State private var isOwnPost = false
     @State private var isBlocked = false
     @State private var isFullAccount = false
     @State private var isFollowing = false
     @State private var showPinThisPostConfirmation = false
-    
+
     init(postMenuContext: PostMenuContext) {
         self.postMenuContext = postMenuContext
         self.nrContact = postMenuContext.nrPost.contact
     }
-    
+
     var body: some View {
         NXForm {
-            
+
             if isOwnPost && self.isFullAccount {
                 Section {
                     // Delete button
@@ -89,15 +89,15 @@ struct PostMenu: View {
                                 .foregroundColor(theme.accent)
                         }
                     }
-              
+
                     Button(action: {
-                        
+
                     }) {
                         Label("Add/remove from Highlights", systemImage: "star")
                             .foregroundColor(theme.accent)
                     }
 #endif
-                    
+
                     if nrPost.isRestricted {
                         NavigationLink {
                             RepublishRestrictedPostSheet(nrPost: nrPost, rootDismiss: dismiss)
@@ -110,12 +110,12 @@ struct PostMenu: View {
                 }
                 .listRowBackground(theme.background)
             }
-            
+
             Section {
                 if !isOwnPost {
                     self.followButton
                 }
-                
+
                 NavigationLink {
                     AddRemoveToListsheet(nrContact: nrContact, onDismiss: { dismiss() })
                         .environmentObject(la)
@@ -126,12 +126,12 @@ struct PostMenu: View {
                     Label("Add/remove from Lists", systemImage: "person.2.crop.square.stack")
                         .foregroundColor(theme.accent)
                 }
-        
+
                 if !isOwnPost {
                     Button(action: {
                         dismiss()
-                        
-                        
+
+
                         if IS_DESKTOP_COLUMNS() {
                             // Create new column, or replace last column (if too many)
                             withAnimation {
@@ -158,7 +158,7 @@ struct PostMenu: View {
                             ObservedPFP(nrContact: nrContact, size: 20)
                         }
                     }
-                    
+
                     Button(action: {
                         navigateToOnMain(ViewPath.ProfileReactionList(pubkey: nrPost.pubkey))
                         dismiss()
@@ -169,9 +169,9 @@ struct PostMenu: View {
                 }
             }
             .listRowBackground(theme.background)
-            
-            
-            
+
+
+
             Section {
                 // TODO: Add unblock { .onAppear.. show time remaining etc blocked() }
                 if !isOwnPost {
@@ -195,7 +195,7 @@ struct PostMenu: View {
                         }
                     }
                 }
-                
+
                 Button(action: {
                     dismiss()
                     L.og.debug("Mute conversation")
@@ -204,7 +204,7 @@ struct PostMenu: View {
                     Label("Mute conversation", systemImage: "bell.slash")
                         .foregroundColor(theme.accent)
                 }
-                
+
                 Button {
                     dismiss()
                     DispatchQueue.main.asyncAfter(deadline: .now() + NEXT_SHEET_DELAY) {
@@ -216,8 +216,8 @@ struct PostMenu: View {
                 }
             }
             .listRowBackground(theme.background)
-            
-            
+
+
             NavigationLink {
                 PostMenuShareSheet(nrPost: nrPost, rootDismiss: dismiss)
             } label: {
@@ -225,7 +225,7 @@ struct PostMenu: View {
                     .foregroundColor(theme.accent)
             }
             .listRowBackground(theme.background)
-            
+
             if !nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 NavigationLink {
                     PostTranslationSheet(nrPost: nrPost, rootDismiss: dismiss)
@@ -235,7 +235,7 @@ struct PostMenu: View {
                 }
                 .listRowBackground(theme.background)
             }
-            
+
             Button {
                 dismiss()
                 if let pn = Event.fetchEvent(id: nrPost.id, context: viewContext())?.privateNote {
@@ -260,28 +260,28 @@ struct PostMenu: View {
             } label: {
                 Label("Post details", systemImage: "info.circle")
                     .foregroundColor(theme.accent)
-                
+
             }
             .listRowBackground(theme.background)
-            
+
         }
 
 //        .scrollContentBackgroundHidden()
 //        .background(theme.listBackground)
-//        
+//
         .onAppear {
             isOwnPost = nrPost.pubkey == la.pubkey
             isBlocked = blocks().contains(nrPost.pubkey)
             self.isFullAccount = la.account.isFullAccount
         }
-        
+
         .nbNavigationDestination(isPresented: $showMultiFollowSheet) {
             MultiFollowSheet(pubkey: nrPost.pubkey, name: nrPost.anyName, onDismiss: { dismiss() })
                 .frame(maxWidth: .infinity, maxHeight: .infinity) // Ensure full screen usage (for bg)
                 .background(theme.listBackground)
                 .environment(\.theme, theme)
         }
-        
+
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Close", systemImage: "xmark") {
@@ -289,9 +289,9 @@ struct PostMenu: View {
                 }
             }
         }
-        
+
     }
-    
+
     @ViewBuilder
     private var followButton: some View {
         Button(action: {
@@ -342,7 +342,7 @@ struct PostMenuButton: View {
     @Environment(\.pinnedPostId) var pinnedPostId
     public let nrPost: NRPost
     public let theme: Theme
-    
+
     var body: some View {
         Image(systemName: "ellipsis")
             .fontWeightBold()
@@ -374,14 +374,14 @@ func unpinPost(_ pinnedPost: NRPost) async {
     let pinEventIds: [String] = await withBgContext { bgContext in
         Event.fetchReplacableEvents(10601, pubkeys: [pinnedPost.pubkey], context: bgContext).map { $0.id }
     }
-    
+
     // Create delete event
     var deleteRequestNEvent = NEvent(content: "")
     deleteRequestNEvent.kind = .delete
     deleteRequestNEvent.tags = pinEventIds.map { eventId in
         NostrTag(["e", eventId])
     }
-    
+
     // sign delete event
     guard let signedDeleteRequestNEvent = try? await Nostur.sign(nEvent: deleteRequestNEvent, accountPubkey: pinnedPost.pubkey)
     else {
@@ -390,15 +390,15 @@ func unpinPost(_ pinnedPost: NRPost) async {
 #endif
         return
     }
-        
+
     // publish signed delete event
     Unpublisher.shared.publishNow(signedDeleteRequestNEvent)
-    
+
     // Handle in own DB
     _ = await withBgContext { bgContext in
         Event.saveEvent(event: signedDeleteRequestNEvent, context: bgContext)
     }
-    
+
 }
 
 #Preview("Post Menu") {

--- a/Nostur/Post/PostMenu/PostTranslationSheet.swift
+++ b/Nostur/Post/PostMenu/PostTranslationSheet.swift
@@ -1,0 +1,86 @@
+//
+//  PostTranslationSheet.swift
+//  Nostur
+//
+
+import SwiftUI
+
+struct PostTranslationSheet: View {
+    @Environment(\.theme) private var theme
+    let nrPost: NRPost
+    var rootDismiss: (() -> Void)? = nil
+    
+    @State private var loadState: LoadState = .loading
+    
+    private enum LoadState {
+        case loading
+        case loaded(String)
+        case notNeeded
+        case failed(String)
+    }
+    
+    var body: some View {
+        NXForm {
+            Section(header: Text("Translation")) {
+                switch loadState {
+                case .loading:
+                    HStack {
+                        ProgressView()
+                        Text("Translating...")
+                            .foregroundColor(.secondary)
+                    }
+                case .loaded(let translation):
+                    Text(translation)
+                        .textSelection(.enabled)
+                case .notNeeded:
+                    Text("This note is already in the target language.")
+                        .foregroundColor(.secondary)
+                case .failed(let message):
+                    Text(message)
+                        .foregroundColor(.red)
+                }
+            }
+            .listRowBackground(theme.background)
+            
+            if case .loaded(let translation) = loadState {
+                Section {
+                    Button {
+                        UIPasteboard.general.string = translation
+                        sendNotification(.anyStatus, (String(localized: "Translation copied to clipboard"), "COPY_TRANSLATION"))
+                    } label: {
+                        Label("Copy translation", systemImage: "doc.on.doc")
+                            .foregroundColor(theme.accent)
+                    }
+                }
+                .listRowBackground(theme.background)
+            }
+        }
+        .nosturNavBgCompat(theme: theme)
+        .navigationTitle("Translate")
+        .task(id: nrPost.id) {
+            await translate()
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close", systemImage: "xmark") {
+                    rootDismiss?()
+                }
+            }
+        }
+    }
+    
+    private func translate() async {
+        do {
+            let translation = try await LibreTranslateService.shared.translatePost(id: nrPost.id, text: nrPost.plainText)
+            if translation.trimmingCharacters(in: .whitespacesAndNewlines) == nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines) {
+                loadState = .notNeeded
+            }
+            else {
+                loadState = .loaded(translation)
+            }
+        }
+        catch {
+            loadState = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/Nostur/Post/PostMenu/PostTranslationSheet.swift
+++ b/Nostur/Post/PostMenu/PostTranslationSheet.swift
@@ -9,16 +9,16 @@ struct PostTranslationSheet: View {
     @Environment(\.theme) private var theme
     let nrPost: NRPost
     var rootDismiss: (() -> Void)? = nil
-    
+
     @State private var loadState: LoadState = .loading
-    
+
     private enum LoadState {
         case loading
         case loaded(String)
         case notNeeded
         case failed(String)
     }
-    
+
     var body: some View {
         NXForm {
             Section(header: Text("Translation")) {
@@ -41,7 +41,7 @@ struct PostTranslationSheet: View {
                 }
             }
             .listRowBackground(theme.background)
-            
+
             if case .loaded(let translation) = loadState {
                 Section {
                     Button {
@@ -68,7 +68,7 @@ struct PostTranslationSheet: View {
             }
         }
     }
-    
+
     private func translate() async {
         do {
             let translation = try await LibreTranslateService.shared.translatePost(id: nrPost.id, text: nrPost.plainText)

--- a/Nostur/Post/PostTranslationInline.swift
+++ b/Nostur/Post/PostTranslationInline.swift
@@ -46,8 +46,19 @@ struct PostTranslationInline: View {
                 .background(theme.secondaryBackground)
                 .cornerRadius(8)
                 .padding(.top, 8)
-            case .notNeeded, .failed:
+            case .notNeeded:
                 EmptyView()
+            case .failed:
+                HStack(spacing: 8) {
+                    Label("Translation unavailable", systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                    Button("Retry") {
+                        Task { await retryTranslate() }
+                    }
+                    .font(.footnote)
+                }
+                .padding(.top, 8)
             }
         }
         .task(id: nrPost.id) {
@@ -76,5 +87,10 @@ struct PostTranslationInline: View {
         catch {
             loadState = .failed
         }
+    }
+
+    private func retryTranslate() async {
+        loadState = .idle
+        await translate()
     }
 }

--- a/Nostur/Post/PostTranslationInline.swift
+++ b/Nostur/Post/PostTranslationInline.swift
@@ -1,0 +1,80 @@
+//
+//  PostTranslationInline.swift
+//  Nostur
+//
+
+import SwiftUI
+
+struct PostTranslationInline: View {
+    @Environment(\.theme) private var theme
+    let nrPost: NRPost
+    
+    @State private var loadState: LoadState = .idle
+    
+    private enum LoadState {
+        case idle
+        case loading
+        case loaded(String)
+        case notNeeded
+        case failed
+    }
+    
+    var body: some View {
+        Group {
+            switch loadState {
+            case .idle:
+                EmptyView()
+            case .loading:
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("Translating...")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.top, 8)
+            case .loaded(let translation):
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("Translation", systemImage: "globe")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(translation)
+                        .font(.body)
+                        .foregroundColor(theme.primary)
+                        .textSelection(.enabled)
+                }
+                .padding(10)
+                .background(theme.secondaryBackground)
+                .cornerRadius(8)
+                .padding(.top, 8)
+            case .notNeeded, .failed:
+                EmptyView()
+            }
+        }
+        .task(id: nrPost.id) {
+            await translate()
+        }
+    }
+    
+    private func translate() async {
+        guard case .idle = loadState else { return }
+        let original = nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !original.isEmpty else {
+            loadState = .notNeeded
+            return
+        }
+        
+        loadState = .loading
+        do {
+            let translation = try await LibreTranslateService.shared.translatePost(id: nrPost.id, text: original)
+            if translation.trimmingCharacters(in: .whitespacesAndNewlines) == original {
+                loadState = .notNeeded
+            }
+            else {
+                loadState = .loaded(translation)
+            }
+        }
+        catch {
+            loadState = .failed
+        }
+    }
+}

--- a/Nostur/Post/PostTranslationInline.swift
+++ b/Nostur/Post/PostTranslationInline.swift
@@ -8,9 +8,9 @@ import SwiftUI
 struct PostTranslationInline: View {
     @Environment(\.theme) private var theme
     let nrPost: NRPost
-    
+
     @State private var loadState: LoadState = .idle
-    
+
     private enum LoadState {
         case idle
         case loading
@@ -18,7 +18,7 @@ struct PostTranslationInline: View {
         case notNeeded
         case failed
     }
-    
+
     var body: some View {
         Group {
             switch loadState {
@@ -54,7 +54,7 @@ struct PostTranslationInline: View {
             await translate()
         }
     }
-    
+
     private func translate() async {
         guard case .idle = loadState else { return }
         let original = nrPost.plainText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -62,7 +62,7 @@ struct PostTranslationInline: View {
             loadState = .notNeeded
             return
         }
-        
+
         loadState = .loading
         do {
             let translation = try await LibreTranslateService.shared.translatePost(id: nrPost.id, text: original)

--- a/Nostur/Screens/Settings/Settings.swift
+++ b/Nostur/Screens/Settings/Settings.swift
@@ -15,57 +15,57 @@ struct Settings: View {
     @EnvironmentObject private var la: LoggedInAccount
     @Environment(\.theme) private var theme
     @ObservedObject private var settings: SettingsStore = .shared
-    
+
     @State var deleteAccountIsShown = false
-    
+
 
     var body: some View {
 #if DEBUG
         let _ = nxLogChanges(of: Self.self)
 #endif
         NXForm {
-            
+
             NavigationLink {
                 AppearanceSettings()
             } label: {
                 Label("Appearance", systemImage: "switch.2")
             }
-            
-  
+
+
             Section {
                 NavigationLink {
                     PostingAndUploadingSettings()
                 } label: {
                     Label("Posting & Media Uploading", systemImage: "icloud.and.arrow.up")
                 }
-                
+
                 NavigationLink {
                     ZapsSettings()
                 } label: {
                     Label("Zaps", systemImage: "bolt")
                 }
-                
+
                 NavigationLink {
                     TranslationSettings()
                 } label: {
                     Label("Translation", systemImage: "globe")
                 }
             }
-            
+
             Section {
                 NavigationLink {
                     RelaysAndConnectionsSettings()
                 } label: {
                     Label("Relay Connections", systemImage: "point.3.filled.connected.trianglepath.dotted")
                 }
-                
+
                 NavigationLink {
                     SpamFilteringSettings()
                 } label: {
                     Label("Spam Filtering", systemImage: "checkmark.shield")
                 }
             }
-                  
+
             Section(header: Text("Data Usage", comment: "Setting heading on settings screen")) {
                 Toggle(isOn: $settings.lowDataMode) {
                     VStack(alignment: .leading) {
@@ -76,19 +76,19 @@ struct Settings: View {
                     }
                 }
             }
-            
+
             NavigationLink {
                 DatabaseAndCacheSettings()
             } label: {
                 Label("Database & Cache", systemImage: "cylinder.split.1x2")
             }
-            
-       
-            
 
-            
-            
-            
+
+
+
+
+
+
             if account()?.privateKey != nil && !(account()?.isNC ?? false) {
                 Section(header: Text("Account", comment: "Heading for section to delete account")) {
                     NavigationLink {
@@ -101,7 +101,7 @@ struct Settings: View {
                         deleteAccountIsShown = true
                     } label: {
                         Label(String(localized:"Delete account", comment: "Button to delete account"), systemImage: "trash")
-                    }                    
+                    }
                 }
                 .listRowBackground(theme.background)
             }
@@ -143,7 +143,7 @@ extension Localizable {
 struct FooterConfiguratorLink: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var settings: SettingsStore = .shared
-    
+
     var body: some View {
         NavigationLink(destination: {
             FooterConfigurator(footerButtons: $settings.footerButtons)
@@ -161,7 +161,7 @@ struct FooterConfiguratorLink: View {
 struct RelayMasteryLink: View {
     @Environment(\.theme) private var theme
     @State private var relays: [CloudRelay] = []
-    
+
     var body: some View {
         NavigationLink(destination: {
             RelayMastery(relays: relays)
@@ -183,7 +183,7 @@ struct RelayMasteryLink: View {
 
 struct RelaysLink: View {
     @Environment(\.theme) private var theme
-    
+
     var body: some View {
         NavigationLink(destination: {
             RelaysView()

--- a/Nostur/Screens/Settings/Settings.swift
+++ b/Nostur/Screens/Settings/Settings.swift
@@ -44,6 +44,12 @@ struct Settings: View {
                 } label: {
                     Label("Zaps", systemImage: "bolt")
                 }
+                
+                NavigationLink {
+                    TranslationSettings()
+                } label: {
+                    Label("Translation", systemImage: "globe")
+                }
             }
             
             Section {

--- a/Nostur/Screens/Settings/SettingsStore.swift
+++ b/Nostur/Screens/Settings/SettingsStore.swift
@@ -8,11 +8,13 @@
 import Foundation
 import SwiftUI
 import Combine
+import KeychainAccess
 
 final class SettingsStore: ObservableObject {
 
     public static let shared = SettingsStore()
     static let deviceDefaultFiatCurrency = "__device_default__"
+    private static let translationAPIKeyKeychainKey = "libretranslate_api_key"
 
     public enum Keys {
         static let lastMaintenanceTimestamp:String = "last_maintenance_timestamp"
@@ -75,6 +77,8 @@ final class SettingsStore: ObservableObject {
 
 //    private let cancellable: Cancellable
     private let defaults: UserDefaults
+    private let translationKeychain = Keychain(service: "nostur.com.Nostur.translation")
+        .synchronizable(true)
 
     let objectWillChange = PassthroughSubject<Void, Never>()
 
@@ -209,7 +213,6 @@ final class SettingsStore: ObservableObject {
             Keys.blossomServerList: [],
             Keys.translationAutoTranslate: false,
             Keys.translationServiceURL: "https://translate.nostr.wine",
-            Keys.translationAPIKey: "",
             Keys.translationSourceLanguage: "auto",
             Keys.translationTargetLanguage: Locale.current.language.languageCode?.identifier ?? "en"
         ])
@@ -290,8 +293,45 @@ final class SettingsStore: ObservableObject {
     }
 
     var translationAPIKey: String {
-        set { defaults.set(newValue, forKey: Keys.translationAPIKey); objectWillChange.send() }
-        get { defaults.string(forKey: Keys.translationAPIKey) ?? "" }
+        set {
+            if newValue.isEmpty {
+                try? translationKeychain.remove(Self.translationAPIKeyKeychainKey)
+                defaults.removeObject(forKey: Keys.translationAPIKey)
+            }
+            else {
+                do {
+                    try translationKeychain
+                        .accessibility(.afterFirstUnlock)
+                        .set(newValue, key: Self.translationAPIKeyKeychainKey)
+                    defaults.removeObject(forKey: Keys.translationAPIKey)
+                }
+                catch {
+                    L.og.error("🔴🔴🔴 could not update translation API key in keychain")
+                }
+            }
+            objectWillChange.send()
+        }
+        get {
+            if let apiKey = try? translationKeychain.get(Self.translationAPIKeyKeychainKey), !apiKey.isEmpty {
+                return apiKey
+            }
+
+            guard let legacyAPIKey = defaults.string(forKey: Keys.translationAPIKey), !legacyAPIKey.isEmpty else {
+                return ""
+            }
+
+            do {
+                try translationKeychain
+                    .accessibility(.afterFirstUnlock)
+                    .set(legacyAPIKey, key: Self.translationAPIKeyKeychainKey)
+                defaults.removeObject(forKey: Keys.translationAPIKey)
+            }
+            catch {
+                L.og.error("🔴🔴🔴 could not migrate translation API key to keychain")
+            }
+
+            return legacyAPIKey
+        }
     }
 
     var translationSourceLanguage: String {

--- a/Nostur/Screens/Settings/SettingsStore.swift
+++ b/Nostur/Screens/Settings/SettingsStore.swift
@@ -10,16 +10,16 @@ import SwiftUI
 import Combine
 
 final class SettingsStore: ObservableObject {
-    
+
     public static let shared = SettingsStore()
     static let deviceDefaultFiatCurrency = "__device_default__"
-    
+
     public enum Keys {
         static let lastMaintenanceTimestamp:String = "last_maintenance_timestamp"
-        
+
         static let isSignatureVerificationEnabled:String = "signature_verification_enabled"
         static let replaceNsecWithHunter2:String = "replace_nsec_with_hunter2"
-        
+
         static let defaultZapAmount:String = "default_zap_amount"
         static let showFiat:String = "show_fiat"
         static let preferredFiatCurrency:String = "preferred_fiat_currency"
@@ -39,33 +39,33 @@ final class SettingsStore: ObservableObject {
         static let activeNWCconnectionId:String = "active_nwc_connection_id"
         static let fetchCounts:String = "fetch_counts"
         static let includeSharedFrom:String = "include_shared_from"
-        
+
         static let webOfTrustLevel:String = "web_of_trust_level"
         static let autoHideBars:String = "auto_hide_bars"
         static let lowDataMode:String = "low_data_mode"
         static let footerButtons:String = "footer_buttons"
-        
+
         static let nwcShowBalance:String = "nwc_show_balance"
         static let appWideSeenTracker:String = "app_wide_seen_tracker"
         static let appWideSeenTrackeriCloud:String = "app_wide_seen_tracker_icloud"
         static let mainWoTaccountPubkey:String = "main_wot_account_pubkey"
-        
+
         static let postUserAgentEnabled:String = "post_user_agent_enabled"
         static let displayUserAgentEnabled:String = "display_user_agent_enabled"
         static let excludedUserAgentPubkeys:String = "excluded_user_agent_pubkeys"
-        
+
         static let receiveLocalNotifications:String = "receive_local_notifications"
         static let receiveLocalNotificationsLimitToFollows:String = "receive_local_notifications_limit_to_follows"
-        
+
         static let followRelayHints:String = "follow_relay_hints"
         static let enableOutboxRelays:String = "outbox_enabled"
         static let enableVPNdetection:String = "vpn_detection_enabled"
         static let enableOutboxPreview:String = "outbox_preview_enabled"
-        
+
         static let proMode:String = "nostur_pro_mode"
-        
+
         static let blossomServerList:String = "blossom_server_list"
-        
+
         static let translationAutoTranslate:String = "translation_auto_translate"
         static let translationServiceURL:String = "translation_service_url"
         static let translationAPIKey:String = "translation_api_key"
@@ -77,17 +77,17 @@ final class SettingsStore: ObservableObject {
     private let defaults: UserDefaults
 
     let objectWillChange = PassthroughSubject<Void, Never>()
-    
+
     enum WebOfTrustLevel:String, CaseIterable, Localizable, Identifiable {
         case off = "WOT_OFF"
         case normal = "WOT_NORMAL"
         case strict = "WOT_STRICT"
-        
+
         var id:String {
             String(self.rawValue)
         }
     }
-    
+
     public static let walletOptions:[LightningWallet] = [
         LightningWallet(name: "none", scheme: "lightning:"),
         LightningWallet(name: "Alby Go", scheme: "alby:"),
@@ -103,12 +103,12 @@ final class SettingsStore: ObservableObject {
         LightningWallet(name: "Alby (Nostr Wallet Connect)", scheme: "nostur:nwc:alby:"), // NWC
         LightningWallet(name: "Custom Nostr Wallet Connect...", scheme: "nostur:nwc:custom:") // CUSTOM NWC
     ]
-    
+
     public static let mediaUploadServiceOptions:[MediaUploadService] = [
 
          // link will be just the image url but need to replace http with https
         getVoidCatService(),
-        
+
         MediaUploadService(name: "nostrcheck.me", request: { imageData, usePNG in
             // Dummy function body just to be compatible with MediaUploadService
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
@@ -120,7 +120,7 @@ final class SettingsStore: ObservableObject {
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
             return "https://localhost"
         }),
-        
+
         MediaUploadService(name: "nostr.build", request: { imageData, usePNG in
             // Dummy function body just to be compatible with MediaUploadService
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
@@ -135,7 +135,7 @@ final class SettingsStore: ObservableObject {
 
         // needs registered Client ID
         getImgurService(),
-        
+
         MediaUploadService(name: NIP96_LABEL, request: { imageData, usePNG in
             // Dummy function body just to be compatible with MediaUploadService
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
@@ -147,7 +147,7 @@ final class SettingsStore: ObservableObject {
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
             return "https://localhost"
         }),
-        
+
         MediaUploadService(name: BLOSSOM_LABEL, request: { imageData, usePNG in
             // Dummy function body just to be compatible with MediaUploadService
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
@@ -159,12 +159,12 @@ final class SettingsStore: ObservableObject {
             // We only need .name for the Picker in Settings, handle actual implementation with NostrEssentials Nip96Uploader
             return "https://localhost"
         })
-        
+
     ]
-    
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        
+
         defaults.register(defaults: [
             Keys.lastMaintenanceTimestamp: 0,
             Keys.replaceNsecWithHunter2: true,
@@ -221,7 +221,7 @@ final class SettingsStore: ObservableObject {
 //            .print("UserDefaults.didChangeNotificatio")
 //            .map { _ in () }
 //            .subscribe(objectWillChange)
-        
+
         // TODO: Refactor settings, better use all properties on SettingsStore directly instead of (slower) defaults.bool()
         // for now only a few that we need right now:
         _enableOutboxRelays = defaults.bool(forKey: Keys.enableOutboxRelays)
@@ -244,11 +244,11 @@ final class SettingsStore: ObservableObject {
         _appWideSeenTracker = defaults.bool(forKey: Keys.appWideSeenTracker)
         _appWideSeenTrackeriCloud = defaults.bool(forKey: Keys.appWideSeenTrackeriCloud)
         _mainWoTaccountPubkey = defaults.string(forKey: Keys.mainWoTaccountPubkey) ?? ""
-        
+
         // optimize
         self.updateNWCreadyCache()
     }
-    
+
     var defaultMediaUploadService: MediaUploadService {
         get {
             return defaults.string(forKey: Keys.defaultMediaUploadService)
@@ -263,47 +263,47 @@ final class SettingsStore: ObservableObject {
             defaults.set(newValue.id, forKey: Keys.defaultMediaUploadService); objectWillChange.send()
         }
     }
-    
+
     var lastMaintenanceTimestamp: Int {
         set { defaults.set(newValue, forKey: Keys.lastMaintenanceTimestamp) }
         get { defaults.integer(forKey: Keys.lastMaintenanceTimestamp) }
     }
-    
+
     var hideBadges: Bool {
         set { defaults.set(newValue, forKey: Keys.hideBadges); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.hideBadges) }
     }
-    
+
     var includeSharedFrom: Bool {
         set { defaults.set(newValue, forKey: Keys.includeSharedFrom); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.includeSharedFrom) }
     }
-    
+
     var translationAutoTranslate: Bool {
         set { defaults.set(newValue, forKey: Keys.translationAutoTranslate); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.translationAutoTranslate) }
     }
-    
+
     var translationServiceURL: String {
         set { defaults.set(newValue, forKey: Keys.translationServiceURL); objectWillChange.send() }
         get { defaults.string(forKey: Keys.translationServiceURL) ?? "https://translate.nostr.wine" }
     }
-    
+
     var translationAPIKey: String {
         set { defaults.set(newValue, forKey: Keys.translationAPIKey); objectWillChange.send() }
         get { defaults.string(forKey: Keys.translationAPIKey) ?? "" }
     }
-    
+
     var translationSourceLanguage: String {
         set { defaults.set(newValue, forKey: Keys.translationSourceLanguage); objectWillChange.send() }
         get { defaults.string(forKey: Keys.translationSourceLanguage) ?? "auto" }
     }
-    
+
     var translationTargetLanguage: String {
         set { defaults.set(newValue, forKey: Keys.translationTargetLanguage); objectWillChange.send() }
         get { defaults.string(forKey: Keys.translationTargetLanguage) ?? "en" }
     }
-    
+
     var postUserAgentEnabled: Bool {
         set { defaults.set(newValue, forKey: Keys.postUserAgentEnabled); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.postUserAgentEnabled) }
@@ -313,17 +313,17 @@ final class SettingsStore: ObservableObject {
         set { defaults.set(newValue, forKey: Keys.statusBubble); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.statusBubble) }
     }
-    
+
     var enableLiveEvents: Bool {
         set { defaults.set(newValue, forKey: Keys.enableLiveEvents); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.enableLiveEvents) }
     }
-    
+
     var autoScroll: Bool {
         set { defaults.set(newValue, forKey: Keys.autoScroll); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.autoScroll) }
     }
-    
+
     var nwcShowBalance: Bool {
         set { defaults.set(newValue, forKey: Keys.nwcShowBalance); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.nwcShowBalance) }
@@ -333,9 +333,9 @@ final class SettingsStore: ObservableObject {
 //        set { defaults.set(newValue, forKey: Keys.hideEmojisInNames); objectWillChange.send() }
 //        get { defaults.bool(forKey: Keys.hideEmojisInNames) }
 //    }
-    
+
     var isSignatureVerificationEnabled: Bool {
-        set { 
+        set {
             defaults.set(newValue, forKey: Keys.isSignatureVerificationEnabled)
             bg().perform {
                 MessageParser.shared.isSignatureVerificationEnabled = newValue
@@ -343,12 +343,12 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.bool(forKey: Keys.isSignatureVerificationEnabled) }
     }
-    
+
     var replaceNsecWithHunter2Enabled: Bool {
         set { defaults.set(newValue, forKey: Keys.replaceNsecWithHunter2) }
         get { defaults.bool(forKey: Keys.replaceNsecWithHunter2) }
     }
-    
+
     var proMode: Bool {
         set { objectWillChange.send(); defaults.set(newValue, forKey: Keys.proMode) }
         get { defaults.bool(forKey: Keys.proMode) }
@@ -358,7 +358,7 @@ final class SettingsStore: ObservableObject {
         set { objectWillChange.send(); defaults.set(newValue, forKey: Keys.defaultZapAmount) }
         get { defaults.double(forKey: Keys.defaultZapAmount) }
     }
-    
+
     var activeNWCconnectionId: String {
         set {
             objectWillChange.send();
@@ -367,7 +367,7 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.string(forKey: Keys.activeNWCconnectionId) ?? "" }
     }
-    
+
     var excludedUserAgentPubkeys: Set<String> {
         set {
             objectWillChange.send();
@@ -400,12 +400,12 @@ final class SettingsStore: ObservableObject {
             updateNWCreadyCache()
         }
     }
-    
+
     var receiveLocalNotifications: Bool {
         set { defaults.set(newValue, forKey: Keys.receiveLocalNotifications); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.receiveLocalNotifications) }
-    }    
-    
+    }
+
     var receiveLocalNotificationsLimitToFollows: Bool {
         set {
             objectWillChange.send()
@@ -413,7 +413,7 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.bool(forKey: Keys.receiveLocalNotificationsLimitToFollows) }
     }
-    
+
     var thunderzapLevel: String {
         set {
             objectWillChange.send();
@@ -421,14 +421,14 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.string(forKey: Keys.thunderzapLevel) ?? ThunderzapLevel.normal.rawValue }
     }
-    
+
     var followRelayHints: Bool {
         set { defaults.set(newValue, forKey: Keys.followRelayHints); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.followRelayHints) }
     }
-    
+
     // MARK: -- SPECIAL HANDLING FOR PERFORMANCE ON EVERYTHING BELOW:
-    
+
     public var enableOutboxRelays: Bool {
         set {
             objectWillChange.send()
@@ -437,9 +437,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _enableOutboxRelays }
     }
-    
+
     private var _enableOutboxRelays:Bool = false
-    
+
     public var enableOutboxPreview: Bool {
         set {
             objectWillChange.send()
@@ -448,9 +448,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _enableOutboxPreview }
     }
-    
+
     private var _enableOutboxPreview:Bool = false
-    
+
     public var enableVPNdetection: Bool {
         set {
             objectWillChange.send()
@@ -459,9 +459,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _enableVPNdetection }
     }
-    
+
     private var _enableVPNdetection:Bool = false
-    
+
     var webOfTrustLevel: String {
         set {
             objectWillChange.send(); defaults.set(newValue, forKey: Keys.webOfTrustLevel)
@@ -469,7 +469,7 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.string(forKey: Keys.webOfTrustLevel) ?? WebOfTrustLevel.normal.rawValue }
     }
-    
+
     // Instruments:
     // 10.00 ms    0.0%    0 s           SettingsStore.animatedPFPenabled.getter
     public var animatedPFPenabled: Bool {
@@ -480,9 +480,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _animatedPFPenabledCache }
     }
-    
+
     private var _animatedPFPenabledCache:Bool = false
-    
+
     public var lowDataMode: Bool {
         set {
             objectWillChange.send()
@@ -491,9 +491,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _lowDataModeCache }
     }
-    
+
     private var _lowDataModeCache:Bool = false
-    
+
     var rowFooterEnabled: Bool {
         set {
             objectWillChange.send()
@@ -505,9 +505,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _rowFooterEnabled }
     }
-    
+
     private var _rowFooterEnabled:Bool = true
-    
+
     var displayUserAgentEnabled: Bool {
         set {
             objectWillChange.send()
@@ -516,9 +516,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _displayUserAgentEnabled }
     }
-    
+
     private var _displayUserAgentEnabled:Bool = true
-    
+
     var showFiat: Bool {
         set {
             objectWillChange.send()
@@ -530,7 +530,7 @@ final class SettingsStore: ObservableObject {
         }
         get { _showFiat }
     }
-    
+
     var preferredFiatCurrency: String {
         set {
             objectWillChange.send()
@@ -539,9 +539,9 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.string(forKey: Keys.preferredFiatCurrency) ?? Self.deviceDefaultFiatCurrency }
     }
-    
+
     private var _showFiat:Bool = true
-    
+
     public var restrictAutoDownload: Bool {
         set {
             objectWillChange.send()
@@ -550,9 +550,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _restrictAutoDownload }
     }
-    
+
     private var _restrictAutoDownload:Bool = false
-    
+
     public var autoDownloadFrom: String {
         set {
             objectWillChange.send(); defaults.set(newValue, forKey: Keys.autoDownloadFrom)
@@ -560,9 +560,9 @@ final class SettingsStore: ObservableObject {
         }
         get { defaults.string(forKey: Keys.autoDownloadFrom) ?? AutodownloadLevel.onlyWoT.rawValue }
     }
-    
+
     private var _autoDownloadFrom:String = AutodownloadLevel.onlyWoT.rawValue
-    
+
     // Starting iOS 26, full width is always on
     public var fullWidthImages: Bool {
         set {
@@ -577,9 +577,9 @@ final class SettingsStore: ObservableObject {
             return _fullWidthImages
         }
     }
-    
+
     private var _fullWidthImages:Bool = false
-    
+
     public var footerButtons: String {
         set {
             objectWillChange.send()
@@ -589,9 +589,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _footerButtons }
     }
-    
+
     private var _footerButtons: String = "💬🔄+⚡️🔖"
-    
+
     public var fetchCounts: Bool {
         set {
             objectWillChange.send()
@@ -600,9 +600,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _fetchCounts }
     }
-    
+
     private var _fetchCounts:Bool = false
-    
+
     public var appWideSeenTracker: Bool {
         set {
             objectWillChange.send()
@@ -611,9 +611,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _appWideSeenTracker }
     }
-    
+
     private var _appWideSeenTracker:Bool = false
-    
+
     public var appWideSeenTrackeriCloud: Bool {
         set {
             objectWillChange.send()
@@ -622,19 +622,19 @@ final class SettingsStore: ObservableObject {
         }
         get { _appWideSeenTrackeriCloud }
     }
-    
+
     private var _appWideSeenTrackeriCloud:Bool = false
-    
-    
+
+
     var blossomServerList: [String] {
         set { defaults.set(newValue, forKey: Keys.blossomServerList) }
         get { defaults.array(forKey: Keys.blossomServerList) as? [String] ?? [] }
     }
-    
+
     // optimize
-    
+
     public var nwcReady:Bool = false
-    
+
     private func isNWCready() -> Bool {
         defaultLightningWallet.scheme.contains(":nwc:") && !activeNWCconnectionId.isEmpty
     }
@@ -645,7 +645,7 @@ final class SettingsStore: ObservableObject {
             self.nwcReady = self.isNWCready()
         }
     }
-    
+
     public var mainWoTaccountPubkey: String {
         set {
             objectWillChange.send()
@@ -654,9 +654,9 @@ final class SettingsStore: ObservableObject {
         }
         get { _mainWoTaccountPubkey }
     }
-    
+
     private var _mainWoTaccountPubkey:String = ""
-    
+
     @MainActor
     static func shouldAutodownload(_ nrPost: NRPost, la laOrNil: LoggedInAccount? = nil) -> Bool {
         let la: LoggedInAccount? = laOrNil ?? AccountsState.shared.loggedInAccount
@@ -677,7 +677,7 @@ final class SettingsStore: ObservableObject {
             return true
         }
     }
-    
+
     @MainActor
     static func shouldAutodownload(_ nrPost: NRLiveEvent, la laOrNil: LoggedInAccount? = nil) -> Bool {
         let la: LoggedInAccount? = laOrNil ?? AccountsState.shared.loggedInAccount
@@ -698,7 +698,7 @@ final class SettingsStore: ObservableObject {
             return true
         }
     }
-    
+
     static func shouldAutodownload(_ nrChat: NRChatMessage) -> Bool {
         if nrChat.following { return true }
         if AccountsState.shared.bgFullAccountPubkeys.contains(nrChat.pubkey) { return true }
@@ -714,7 +714,7 @@ final class SettingsStore: ObservableObject {
             return true
         }
     }
-    
+
     static func shouldAutodownload(_ nxEvent: NXEvent) -> Bool {
         if AccountsState.shared.bgFullAccountPubkeys.contains(nxEvent.pubkey) { return true }
         switch SettingsStore.shared.autoDownloadFrom {
@@ -743,7 +743,7 @@ enum AutodownloadLevel:String, CaseIterable, Localizable, Identifiable {
     case all = "AUTODOWNLOAD_ALL"
     case onlyWoT = "AUTODOWNLOAD_WOT_NORMAL"
     case onlyWoTstrict = "AUTODOWNLOAD_WOT_STRICT"
-    
+
     var id:String {
         String(self.rawValue)
     }
@@ -753,7 +753,7 @@ enum ThunderzapLevel:String, CaseIterable, Localizable, Identifiable {
     case normal = "THUNDERZAP_NORMAL"
     case low = "THUNDERZAP_LOW"
     case off = "THUNDERZAP_OFF"
-    
+
     var id:String {
         String(self.rawValue)
     }

--- a/Nostur/Screens/Settings/SettingsStore.swift
+++ b/Nostur/Screens/Settings/SettingsStore.swift
@@ -65,6 +65,12 @@ final class SettingsStore: ObservableObject {
         static let proMode:String = "nostur_pro_mode"
         
         static let blossomServerList:String = "blossom_server_list"
+        
+        static let translationAutoTranslate:String = "translation_auto_translate"
+        static let translationServiceURL:String = "translation_service_url"
+        static let translationAPIKey:String = "translation_api_key"
+        static let translationSourceLanguage:String = "translation_source_language"
+        static let translationTargetLanguage:String = "translation_target_language"
     }
 
 //    private let cancellable: Cancellable
@@ -200,7 +206,12 @@ final class SettingsStore: ObservableObject {
             Keys.enableOutboxPreview: false,
             Keys.enableVPNdetection: true,
             Keys.proMode: false,
-            Keys.blossomServerList: []
+            Keys.blossomServerList: [],
+            Keys.translationAutoTranslate: false,
+            Keys.translationServiceURL: "https://translate.nostr.wine",
+            Keys.translationAPIKey: "",
+            Keys.translationSourceLanguage: "auto",
+            Keys.translationTargetLanguage: Locale.current.language.languageCode?.identifier ?? "en"
         ])
 
         // Don't use this anymore because re-renders too much, like when moving window on macOS
@@ -266,6 +277,31 @@ final class SettingsStore: ObservableObject {
     var includeSharedFrom: Bool {
         set { defaults.set(newValue, forKey: Keys.includeSharedFrom); objectWillChange.send() }
         get { defaults.bool(forKey: Keys.includeSharedFrom) }
+    }
+    
+    var translationAutoTranslate: Bool {
+        set { defaults.set(newValue, forKey: Keys.translationAutoTranslate); objectWillChange.send() }
+        get { defaults.bool(forKey: Keys.translationAutoTranslate) }
+    }
+    
+    var translationServiceURL: String {
+        set { defaults.set(newValue, forKey: Keys.translationServiceURL); objectWillChange.send() }
+        get { defaults.string(forKey: Keys.translationServiceURL) ?? "https://translate.nostr.wine" }
+    }
+    
+    var translationAPIKey: String {
+        set { defaults.set(newValue, forKey: Keys.translationAPIKey); objectWillChange.send() }
+        get { defaults.string(forKey: Keys.translationAPIKey) ?? "" }
+    }
+    
+    var translationSourceLanguage: String {
+        set { defaults.set(newValue, forKey: Keys.translationSourceLanguage); objectWillChange.send() }
+        get { defaults.string(forKey: Keys.translationSourceLanguage) ?? "auto" }
+    }
+    
+    var translationTargetLanguage: String {
+        set { defaults.set(newValue, forKey: Keys.translationTargetLanguage); objectWillChange.send() }
+        get { defaults.string(forKey: Keys.translationTargetLanguage) ?? "en" }
     }
     
     var postUserAgentEnabled: Bool {

--- a/Nostur/Screens/Settings/TranslationSettings.swift
+++ b/Nostur/Screens/Settings/TranslationSettings.swift
@@ -1,0 +1,62 @@
+//
+//  TranslationSettings.swift
+//  Nostur
+//
+
+import SwiftUI
+
+struct TranslationSettings: View {
+    @Environment(\.theme) private var theme
+    @ObservedObject private var settings: SettingsStore = .shared
+    
+    var body: some View {
+        NXForm {
+            Section(header: Text("Translation", comment: "Setting heading on settings screen")) {
+                Toggle(isOn: $settings.translationAutoTranslate) {
+                    VStack(alignment: .leading) {
+                        Text("Automatically translate notes", comment: "Setting on settings screen")
+                        Text("Shows translations inline using your configured service", comment: "Setting on settings screen")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                TextField("Service URL", text: $settings.translationServiceURL)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                    .keyboardType(.URL)
+                
+                SecureField("API key", text: $settings.translationAPIKey)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                
+                TextField("Source language code", text: $settings.translationSourceLanguage)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                
+                TextField("Target language code", text: $settings.translationTargetLanguage)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+            }
+            .listRowBackground(theme.background)
+            
+            Section {
+                Text("Use any LibreTranslate-compatible endpoint. The default is translate.nostr.wine. Language values should be ISO codes like en, es, fr, de, or ja; use auto for source when the service supports detection.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            .listRowBackground(theme.background)
+        }
+        .nosturNavBgCompat(theme: theme)
+        .navigationTitle("Translation")
+    }
+}
+
+#Preview("Translation Settings") {
+    PreviewContainer {
+        NBNavigationStack {
+            TranslationSettings()
+                .environment(\.theme, Themes.default.theme)
+        }
+    }
+}

--- a/Nostur/Screens/Settings/TranslationSettings.swift
+++ b/Nostur/Screens/Settings/TranslationSettings.swift
@@ -41,6 +41,10 @@ struct TranslationSettings: View {
             .listRowBackground(theme.background)
 
             Section {
+                Text("Translations send note text to the configured service. Only enable automatic translation with a provider you trust.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+
                 Text("Use any LibreTranslate-compatible endpoint. The default is translate.nostr.wine. Language values should be ISO codes like en, es, fr, de, or ja; use auto for source when the service supports detection.")
                     .font(.footnote)
                     .foregroundColor(.secondary)

--- a/Nostur/Screens/Settings/TranslationSettings.swift
+++ b/Nostur/Screens/Settings/TranslationSettings.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct TranslationSettings: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var settings: SettingsStore = .shared
-    
+
     var body: some View {
         NXForm {
             Section(header: Text("Translation", comment: "Setting heading on settings screen")) {
@@ -20,26 +20,26 @@ struct TranslationSettings: View {
                             .foregroundColor(.secondary)
                     }
                 }
-                
+
                 TextField("Service URL", text: $settings.translationServiceURL)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
                     .keyboardType(.URL)
-                
+
                 SecureField("API key", text: $settings.translationAPIKey)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
-                
+
                 TextField("Source language code", text: $settings.translationSourceLanguage)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
-                
+
                 TextField("Target language code", text: $settings.translationTargetLanguage)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
             }
             .listRowBackground(theme.background)
-            
+
             Section {
                 Text("Use any LibreTranslate-compatible endpoint. The default is translate.nostr.wine. Language values should be ISO codes like en, es, fr, de, or ja; use auto for source when the service supports detection.")
                     .font(.footnote)

--- a/Nostur/Utils/LibreTranslateService.swift
+++ b/Nostur/Utils/LibreTranslateService.swift
@@ -3,6 +3,7 @@
 //  Nostur
 //
 
+import CryptoKit
 import Foundation
 
 enum LibreTranslateError: LocalizedError {
@@ -28,7 +29,10 @@ enum LibreTranslateError: LocalizedError {
 actor LibreTranslateService {
     static let shared = LibreTranslateService()
 
+    private let maxConcurrentRequests = 3
     private var cache: [String: String] = [:]
+    private var activeRequests = 0
+    private var requestWaiters: [CheckedContinuation<Void, Never>] = []
 
     private struct TranslateRequest: Encodable {
         let q: String
@@ -46,7 +50,7 @@ actor LibreTranslateService {
         guard !trimmed.isEmpty else { throw LibreTranslateError.emptyText }
 
         let target = normalizedTargetLanguage()
-        let cacheKey = "\(id)|\(target)|\(trimmed.hashValue)"
+        let cacheKey = "\(id)|\(target)|\(stableCacheDigest(trimmed))"
         if let cached = cache[cacheKey] {
             return cached
         }
@@ -56,6 +60,9 @@ actor LibreTranslateService {
             cache[cacheKey] = trimmed
             return trimmed
         }
+
+        await acquireRequestSlot()
+        defer { releaseRequestSlot() }
 
         let translated = try await translate(trimmed, source: source, target: target, apiKey: normalizedAPIKey())
         cache[cacheKey] = translated
@@ -108,5 +115,31 @@ actor LibreTranslateService {
         }
 
         return try JSONDecoder().decode(TranslateResponse.self, from: data).translatedText
+    }
+
+    private func acquireRequestSlot() async {
+        if activeRequests < maxConcurrentRequests {
+            activeRequests += 1
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            requestWaiters.append(continuation)
+        }
+    }
+
+    private func releaseRequestSlot() {
+        if requestWaiters.isEmpty {
+            activeRequests -= 1
+        }
+        else {
+            requestWaiters.removeFirst().resume()
+        }
+    }
+
+    private func stableCacheDigest(_ text: String) -> String {
+        SHA256.hash(data: Data(text.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }

--- a/Nostur/Utils/LibreTranslateService.swift
+++ b/Nostur/Utils/LibreTranslateService.swift
@@ -1,0 +1,112 @@
+//
+//  LibreTranslateService.swift
+//  Nostur
+//
+
+import Foundation
+
+enum LibreTranslateError: LocalizedError {
+    case invalidServiceURL
+    case emptyText
+    case invalidResponse
+    case requestFailed(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidServiceURL:
+            return String(localized: "Invalid translation service URL")
+        case .emptyText:
+            return String(localized: "There is no text to translate")
+        case .invalidResponse:
+            return String(localized: "The translation service returned an invalid response")
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+actor LibreTranslateService {
+    static let shared = LibreTranslateService()
+    
+    private var cache: [String: String] = [:]
+    
+    private struct TranslateRequest: Encodable {
+        let q: String
+        let source: String
+        let target: String
+        let api_key: String
+    }
+    
+    private struct TranslateResponse: Decodable {
+        let translatedText: String
+    }
+    
+    func translatePost(id: String, text: String) async throws -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw LibreTranslateError.emptyText }
+        
+        let target = normalizedTargetLanguage()
+        let cacheKey = "\(id)|\(target)|\(trimmed.hashValue)"
+        if let cached = cache[cacheKey] {
+            return cached
+        }
+        
+        let source = normalizedSourceLanguage()
+        if source != "auto", source == target {
+            cache[cacheKey] = trimmed
+            return trimmed
+        }
+        
+        let translated = try await translate(trimmed, source: source, target: target, apiKey: normalizedAPIKey())
+        cache[cacheKey] = translated
+        return translated
+    }
+    
+    private func normalizedTargetLanguage() -> String {
+        let language = SettingsStore.shared.translationTargetLanguage
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return language.isEmpty ? "en" : language
+    }
+    
+    private func normalizedSourceLanguage() -> String {
+        let language = SettingsStore.shared.translationSourceLanguage
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return language.isEmpty ? "auto" : language
+    }
+    
+    private func normalizedAPIKey() -> String {
+        SettingsStore.shared.translationAPIKey
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    private func endpoint(_ path: String) throws -> URL {
+        let rawURL = SettingsStore.shared.translationServiceURL
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let baseURL = URL(string: rawURL), let scheme = baseURL.scheme, ["http", "https"].contains(scheme) else {
+            throw LibreTranslateError.invalidServiceURL
+        }
+        if baseURL.lastPathComponent == path {
+            return baseURL
+        }
+        return baseURL.appendingPathComponent(path)
+    }
+    
+    private func translate(_ text: String, source: String, target: String, apiKey: String) async throws -> String {
+        var request = URLRequest(url: try endpoint("translate"))
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(TranslateRequest(q: text, source: source, target: target, api_key: apiKey))
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { throw LibreTranslateError.invalidResponse }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? String(localized: "Translation request failed")
+            throw LibreTranslateError.requestFailed(message)
+        }
+        
+        return try JSONDecoder().decode(TranslateResponse.self, from: data).translatedText
+    }
+}

--- a/Nostur/Utils/LibreTranslateService.swift
+++ b/Nostur/Utils/LibreTranslateService.swift
@@ -10,7 +10,7 @@ enum LibreTranslateError: LocalizedError {
     case emptyText
     case invalidResponse
     case requestFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .invalidServiceURL:
@@ -27,60 +27,60 @@ enum LibreTranslateError: LocalizedError {
 
 actor LibreTranslateService {
     static let shared = LibreTranslateService()
-    
+
     private var cache: [String: String] = [:]
-    
+
     private struct TranslateRequest: Encodable {
         let q: String
         let source: String
         let target: String
         let api_key: String
     }
-    
+
     private struct TranslateResponse: Decodable {
         let translatedText: String
     }
-    
+
     func translatePost(id: String, text: String) async throws -> String {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw LibreTranslateError.emptyText }
-        
+
         let target = normalizedTargetLanguage()
         let cacheKey = "\(id)|\(target)|\(trimmed.hashValue)"
         if let cached = cache[cacheKey] {
             return cached
         }
-        
+
         let source = normalizedSourceLanguage()
         if source != "auto", source == target {
             cache[cacheKey] = trimmed
             return trimmed
         }
-        
+
         let translated = try await translate(trimmed, source: source, target: target, apiKey: normalizedAPIKey())
         cache[cacheKey] = translated
         return translated
     }
-    
+
     private func normalizedTargetLanguage() -> String {
         let language = SettingsStore.shared.translationTargetLanguage
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return language.isEmpty ? "en" : language
     }
-    
+
     private func normalizedSourceLanguage() -> String {
         let language = SettingsStore.shared.translationSourceLanguage
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return language.isEmpty ? "auto" : language
     }
-    
+
     private func normalizedAPIKey() -> String {
         SettingsStore.shared.translationAPIKey
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    
+
     private func endpoint(_ path: String) throws -> URL {
         let rawURL = SettingsStore.shared.translationServiceURL
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -93,20 +93,20 @@ actor LibreTranslateService {
         }
         return baseURL.appendingPathComponent(path)
     }
-    
+
     private func translate(_ text: String, source: String, target: String, apiKey: String) async throws -> String {
         var request = URLRequest(url: try endpoint("translate"))
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(TranslateRequest(q: text, source: source, target: target, api_key: apiKey))
-        
+
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LibreTranslateError.invalidResponse }
         guard (200..<300).contains(httpResponse.statusCode) else {
             let message = String(data: data, encoding: .utf8) ?? String(localized: "Translation request failed")
             throw LibreTranslateError.requestFailed(message)
         }
-        
+
         return try JSONDecoder().decode(TranslateResponse.self, from: data).translatedText
     }
 }


### PR DESCRIPTION
Closes #8.

## Summary
- adds a Translation settings screen for LibreTranslate-compatible services, including service URL, API key, source language, target language, and automatic translation toggle
- adds a Translate action to the post menu for on-demand note translation
- adds optional automatic inline translations for notes when enabled, backed by an in-memory translation cache

## Bounty payment
BTC payout address: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ

## Testing
- `xcrun swiftc -parse Nostur/Utils/LibreTranslateService.swift Nostur/Post/PostTranslationInline.swift Nostur/Post/PostMenu/PostTranslationSheet.swift Nostur/Screens/Settings/TranslationSettings.swift`
- `git diff origin/main --check`
- `curl -Ls -H "Accept: application/vnd.github.v3.diff" https://api.github.com/repos/nostur-com/nostur-ios-public/compare/main...KingParmenides:libretranslate-support-20260510 | git apply --check --whitespace=error`
- `xcodebuild -list -project Nostur.xcodeproj` could not run in this environment because the active developer directory is Command Line Tools rather than full Xcode
