### PR TITLE
Fix unbounded pinch zoom in fullscreen image viewer

### DIFF
--- a/Nostur/Screens/GalleryFullScreenSwiper.swift
+++ b/Nostur/Screens/GalleryFullScreenSwiper.swift
@@ -33,6 +33,8 @@ struct GalleryFullScreenSwiper: View {
     @State private var didSave = false
     
     // Zoom and pan state
+    private let minScale: CGFloat = 1.0 // fit-to-screen
+    private let maxScale: CGFloat = 4.0
     @State private var scale: CGFloat = 1.0
     @State private var lastScale: CGFloat = 1.0
     @State private var position: CGSize = .zero
@@ -347,10 +349,32 @@ struct GalleryFullScreenSwiper: View {
             .onChanged { value in
                 let delta = value / self.lastScale
                 self.lastScale = value
-                self.scale *= delta
+                let newScale = self.scale * delta
+                // Rubber-band resistance beyond min/max, snaps back in .onEnded
+                if newScale < minScale {
+                    self.scale = minScale * sqrt(newScale / minScale)
+                }
+                else if newScale > maxScale {
+                    self.scale = maxScale * sqrt(newScale / maxScale)
+                }
+                else {
+                    self.scale = newScale
+                }
             }
             .onEnded { value in
                 self.lastScale = 1.0
+                if self.scale < minScale {
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.scale = minScale
+                        self.position = .zero
+                    }
+                    self.newPosition = .zero
+                }
+                else if self.scale > maxScale {
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.scale = maxScale
+                    }
+                }
             }
     }
     
@@ -365,9 +389,23 @@ struct GalleryFullScreenSwiper: View {
             }
             .onEnded { value in
                 if scale > 1.0 {
-                    self.newPosition = self.position
+                    // Keep the image on screen, snap back if dragged too far
+                    let clamped = self.clampedPosition(self.position)
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.position = clamped
+                    }
+                    self.newPosition = clamped
                 }
             }
+    }
+
+    private func clampedPosition(_ position: CGSize) -> CGSize {
+        let maxX = max(0, (scale - 1) * fullScreenSize.width / 2)
+        let maxY = max(0, (scale - 1) * fullScreenSize.height / 2)
+        return CGSize(
+            width: min(maxX, max(-maxX, position.width)),
+            height: min(maxY, max(-maxY, position.height))
+        )
     }
     
     func saveCurrentImageToPhotos() {


### PR DESCRIPTION
## What

Pinching in the fullscreen image viewer currently has no limits: pinching out shrinks the image indefinitely (down to a dot), and a zoomed image can be panned fully off screen and left stranded there.

This PR clamps the gestures to the standard iOS photo viewer behavior (Photos app etc.):

- **Minimum scale = fit-to-screen (1x)**: pinching below it meets rubber-band resistance and springs back to 1x on release (position also resets)
- **Maximum scale = 4x**: same rubber-band + spring-back on release
- **Pan stays on screen**: when zoomed, dragging the image too far snaps it back within bounds on release

No other behavior changed. Scope is `zoomGesture`, `panGesture`, and a small `clampedPosition` helper in `GalleryFullScreenSwiper.swift`. Built and tested on iOS Simulator.

## Question on contribution flow

Happy to adjust anything here. Also wanted to ask how you prefer contributions in general: is "open an issue to discuss first for non-obvious changes, direct PR for obvious bugs" the right etiquette for this repo? Asking so future contributions match your workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)