### PR TITLE
Make fullscreen image viewer open/dismiss feel native

### DIFF
--- a/Nostur/Post/ContentRendererParts/Zoomable.swift
+++ b/Nostur/Post/ContentRendererParts/Zoomable.swift
@@ -14,44 +14,43 @@ struct ZoomableItem<Content: View, DetailContent: View>: View {
     private let content: Content
     private let detailContent: DetailContent
     private var frameSize: CGSize? = nil
-    @State private var contentSize: CGSize = CGSize(width: 350, height: 350)
-    @State private var viewPosition: CGPoint = .zero
-    
+
     init(id: String = "Default", @ViewBuilder _ content: () -> Content, frameSize: CGSize? = nil, @ViewBuilder detailContent: () -> DetailContent) {
         self.id = id
         self.content = content()
         self.detailContent = detailContent()
         self.frameSize = frameSize
     }
-    
+
     var body: some View {
-        if #available(iOS 16.0, *) {
-            content
-                .onTapGesture(coordinateSpace: .global) { location in
-                    guard !nxViewingContext.contains(.preview) else { return }
-                    triggerZoom(origin: CGPoint(x: location.x - 30, y: location.y - 30))
+        content
+            .modifier {
+                if let frameSize {
+                    $0.frame(width: frameSize.width, height: frameSize.height)
                 }
-                .modifier {
-                    if let frameSize {
-                        $0.frame(width: frameSize.width, height: frameSize.height)
-                    }
-                    else {
-                        $0
-                    }
+                else {
+                    $0
                 }
-        }
-        else {
-            // Fallback on earlier versions
-            content
-                .onTapGesture {
-                    guard !nxViewingContext.contains(.preview) else { return }
-                    triggerZoom(origin: CGPoint(x: UIScreen.main.bounds.width/2, y: UIScreen.main.bounds.height/2))
+            }
+            .overlay(
+                // Hero zoom: the fullscreen view should grow out of this thumbnail, so measure the
+                // thumbnail's actual frame at tap time (in the paired Zoomable's coordinate space).
+                // Must be an overlay: an Image is opaque to hit testing even without gestures, so a
+                // tap layer behind it would never receive touches.
+                GeometryReader { geo in
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            guard !nxViewingContext.contains(.preview) else { return }
+                            let frame = geo.frame(in: .named("zoomable-\(id)"))
+                            triggerZoom(origin: CGPoint(x: frame.midX, y: frame.midY), startingSize: frame.size)
+                        }
                 }
-        }
+            )
     }
-    
-    private func triggerZoom(origin: CGPoint) {
-        let zoomRequest = ZoomRequested(id: self.id, origin: origin, startingSize: contentSize, content: detailContent)
+
+    private func triggerZoom(origin: CGPoint, startingSize: CGSize) {
+        let zoomRequest = ZoomRequested(id: self.id, origin: origin, startingSize: startingSize, content: detailContent)
         sendNotification(.zoomRequested, zoomRequest)
     }
 }
@@ -82,18 +81,19 @@ struct Zoomable<Content: View>: View {
                 
                 if viewState == .zoomed {
                     ZStack(alignment: .topLeading) {
-                        // Content container
+                        // Content container: laid out at full size once, then transformed from the
+                        // thumbnail's rect to fullscreen (scale/position/opacity are render-server
+                        // animations, cheaper than animating layout)
                         if let detailContent {
                             detailContent
                                 .environment(\.fullScreenSize, fullScreenSize)
-                                .frame(
-                                    width: startingSize.width + (screenSize.width - startingSize.width) * animationProgress,
-                                    height: startingSize.height + (screenSize.height - startingSize.height) * animationProgress
-                                )
+                                .frame(width: screenSize.width, height: screenSize.height)
+                                .scaleEffect(zoomScale)
                                 .position(
                                     x: originOffset.x + ((screenSize.width / 2) - originOffset.x) * animationProgress,
                                     y: originOffset.y + ((screenSize.height / 2) - originOffset.y) * animationProgress
                                 )
+                                .opacity(min(1.0, animationProgress * 2)) // quick fade-in over the thumbnail
                         }
                         
                         CloseButton(action: closeWithAnimation)
@@ -103,6 +103,7 @@ struct Zoomable<Content: View>: View {
                     }
                 }
             }
+            .coordinateSpace(name: "zoomable-\(id)") // ZoomableItem measures thumbnail frames in this space
             .onAppear {
                 screenSize = geometry.size
                 if id == "Default" {
@@ -140,12 +141,21 @@ struct Zoomable<Content: View>: View {
         }
     }
     
+    // Uniform scale that covers the thumbnail's rect at progress 0 and reaches fullscreen at 1
+    private var zoomScale: CGFloat {
+        let startScale = max(
+            startingSize.width / max(1, screenSize.width),
+            startingSize.height / max(1, screenSize.height)
+        )
+        return startScale + (1.0 - startScale) * animationProgress
+    }
+
     private func zoom(from: CGPoint, detailContent: AnyView) {
         self.detailContent = detailContent
         self.viewState = .zoomed
         self.animationProgress = 0
-        
-        withAnimation(.easeOut(duration: 0.1)) {
+
+        withAnimation(.spring(duration: 0.25)) {
             self.animationProgress = 1.0
         }
     }

--- a/Nostur/Screens/GalleryFullScreenSwiper.swift
+++ b/Nostur/Screens/GalleryFullScreenSwiper.swift
@@ -39,11 +39,16 @@ struct GalleryFullScreenSwiper: View {
     @State private var lastScale: CGFloat = 1.0
     @State private var position: CGSize = .zero
     @State private var newPosition: CGSize = .zero
-    @State private var gestureStartTime: Date?
-    
+
     // Interactive dismissal state
-    @State private var dismissProgress: CGFloat = 0
+    @State private var dismissOffset: CGFloat = 0 // tracks the finger 1:1 during swipe-down
     @State private var isDraggingToDismiss = false
+    @State private var isDismissing = false
+
+    // 0...1 over half a screen of downward drag; drives the background fade and chrome opacity
+    private var dismissProgress: CGFloat {
+        min(1.0, max(0, dismissOffset / max(1, fullScreenSize.height * 0.5)))
+    }
     
     // Media Post Preview
     @State private var mediaPostPreview = false
@@ -88,7 +93,7 @@ struct GalleryFullScreenSwiper: View {
         .scrollPosition(id: $activeIndex)
         .frame(width: fullScreenSize.width, height: fullScreenSize.height)
         .scrollDisabled(items.count == 1 || scale > 1.0 || isDraggingToDismiss)
-        .background(Color.black.opacity(1 - dismissProgress))
+        .background(Color.black.opacity(isDismissing ? 0 : 1 - (0.5 * dismissProgress)))
         .overlay(alignment: .leading) { navigationLeftButton }
         .overlay(alignment: .trailing) { navigationRightButton }
         .overlay(alignment: .topTrailing) { saveButton }
@@ -166,7 +171,7 @@ struct GalleryFullScreenSwiper: View {
         .frame(width: fullScreenSize.width, height: fullScreenSize.height)
         .scaleEffect(scale * (1.0 - (0.2 * dismissProgress)))
         .offset(position)
-        .offset(y: dismissProgress * 200)
+        .offset(y: dismissOffset)
         .contentShape(Rectangle())
         .onTapGesture(count: 2) {
             withAnimation {
@@ -304,43 +309,40 @@ struct GalleryFullScreenSwiper: View {
     private var dismissDragGesture: some Gesture {
         DragGesture(minimumDistance: 10, coordinateSpace: .local)
             .onChanged { value in
-                // Only handle vertical drags when not zoomed alot
-                if scale <= 1.3 && value.translation.height > 0 && abs(value.translation.height) > abs(value.translation.width) {
-                    if gestureStartTime == nil {
-                        gestureStartTime = Date()
-                        isDraggingToDismiss = true
-                    }
-                    
-                    // Calculate dismiss progress (0 to 1)
-                    let progress = min(1.0, max(0, value.translation.height / 200))
-                    dismissProgress = progress
+                // Only start on a mostly-vertical downward drag when not zoomed (much)
+                if !isDraggingToDismiss {
+                    guard scale <= 1.3 && value.translation.height > 0 && abs(value.translation.height) > abs(value.translation.width)
+                    else { return }
+                    isDraggingToDismiss = true
                 }
+                // Track the finger 1:1; rubber-band when dragged back up past the start point
+                let height = value.translation.height
+                dismissOffset = height >= 0 ? height : -(3 * sqrt(-height))
             }
             .onEnded { value in
-                if isDraggingToDismiss {
-                    guard let startTime = gestureStartTime else { return }
-                    let duration = Date().timeIntervalSince(startTime)
-                    let quickSwipeThreshold: TimeInterval = 0.25
-                    let dismissThreshold: CGFloat = 0.3
-                    
-                    let shouldDismiss = (duration < quickSwipeThreshold && value.translation.height > 30) || 
-                                      dismissProgress > dismissThreshold
-                    
-                    if shouldDismiss {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            dismissProgress = 1.0
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            sendNotification(.closeFullscreenGallery)
-                        }
-                    } else {
-                        withAnimation(.spring(duration: 0.3)) {
-                            dismissProgress = 0
-                        }
+                guard isDraggingToDismiss else { return }
+                isDraggingToDismiss = false
+
+                // predictedEndTranslation projects ~250ms of deceleration, so this approximates pt/s
+                let velocity = (value.predictedEndTranslation.height - value.translation.height) * 4
+                let shouldDismiss = velocity > 800 || (dismissOffset > fullScreenSize.height * 0.25 && velocity > -100)
+
+                if shouldDismiss {
+                    // Hand the release velocity to the spring so the image keeps the finger's speed
+                    let remaining = max(1, fullScreenSize.height - dismissOffset)
+                    withAnimation(.interpolatingSpring(stiffness: 120, damping: 20, initialVelocity: max(0, velocity) / remaining)) {
+                        dismissOffset = fullScreenSize.height
+                        isDismissing = true
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        sendNotification(.closeFullscreenGallery)
                     }
                 }
-                gestureStartTime = nil
-                isDraggingToDismiss = false
+                else {
+                    withAnimation(.spring(duration: 0.3)) {
+                        dismissOffset = 0
+                    }
+                }
             }
     }
     

--- a/Nostur/Screens/GalleryFullScreenSwiper.swift
+++ b/Nostur/Screens/GalleryFullScreenSwiper.swift
@@ -33,6 +33,8 @@ struct GalleryFullScreenSwiper: View {
     @State private var didSave = false
     
     // Zoom and pan state
+    private let minScale: CGFloat = 1.0 // fit-to-screen
+    private let maxScale: CGFloat = 4.0
     @State private var scale: CGFloat = 1.0
     @State private var lastScale: CGFloat = 1.0
     @State private var position: CGSize = .zero
@@ -347,10 +349,32 @@ struct GalleryFullScreenSwiper: View {
             .onChanged { value in
                 let delta = value / self.lastScale
                 self.lastScale = value
-                self.scale *= delta
+                let newScale = self.scale * delta
+                // Rubber-band resistance beyond min/max, snaps back in .onEnded
+                if newScale < minScale {
+                    self.scale = minScale * sqrt(newScale / minScale)
+                }
+                else if newScale > maxScale {
+                    self.scale = maxScale * sqrt(newScale / maxScale)
+                }
+                else {
+                    self.scale = newScale
+                }
             }
             .onEnded { value in
                 self.lastScale = 1.0
+                if self.scale < minScale {
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.scale = minScale
+                        self.position = .zero
+                    }
+                    self.newPosition = .zero
+                }
+                else if self.scale > maxScale {
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.scale = maxScale
+                    }
+                }
             }
     }
     
@@ -365,9 +389,23 @@ struct GalleryFullScreenSwiper: View {
             }
             .onEnded { value in
                 if scale > 1.0 {
-                    self.newPosition = self.position
+                    // Keep the image on screen, snap back if dragged too far
+                    let clamped = self.clampedPosition(self.position)
+                    withAnimation(.spring(duration: 0.3)) {
+                        self.position = clamped
+                    }
+                    self.newPosition = clamped
                 }
             }
+    }
+
+    private func clampedPosition(_ position: CGSize) -> CGSize {
+        let maxX = max(0, (scale - 1) * fullScreenSize.width / 2)
+        let maxY = max(0, (scale - 1) * fullScreenSize.height / 2)
+        return CGSize(
+            width: min(maxX, max(-maxX, position.width)),
+            height: min(maxY, max(-maxY, position.height))
+        )
     }
     
     func saveCurrentImageToPhotos() {


### PR DESCRIPTION
## What

Follow-up to #64, continuing the goal of making the fullscreen image viewer feel like a native photo viewer (Photos app etc.). Two independent changes, one commit each:

**1. Swipe-down dismiss tracks the finger and respects velocity**
- The photo follows the finger 1:1 the whole way down (previously it pinned in place after 200pt while the background went fully transparent)
- Background fades gradually; dragging back up rubber-bands and cancels
- A quick flick dismisses from any distance; the exit animation inherits the release velocity so the photo continues at the speed it was let go

**2. Opening hero-zooms from the tapped thumbnail**
- Previously the viewer animated a hardcoded 350×350 box from the finger's tap location, and because the gallery is laid out at full screen size, nothing actually scaled — the full-size viewer just slid in diagonally from the tap point
- Now the thumbnail's real frame is measured at tap time and the viewer scales up out of that rect with a 0.25s spring, fading in over the thumbnail. The morph is transform-based (scale/position/opacity) instead of animating layout, so it's also cheaper per frame

Tested on device (iPhone, iOS 18): feed images, GIFs, DM images, profile pictures; paging between multiple images; zoom + dismiss interplay.

## Note on stacking

This branch is based on the #64 branch because both touch `GalleryFullScreenSwiper.swift` — the first commit shown here is #64's. Merging #64 first keeps this PR's diff to just the two commits above.

Per the question in #64 about contribution flow: this one is a behavior change rather than a plain bug fix, so very happy to adjust the feel (spring timing, fade amounts, dismiss thresholds are all single constants) or split/restructure if you'd prefer it discussed in an issue first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)