### PR TITLE
Fix stuck spinner when remote signer connection fails

### DIFF
--- a/Nostur/Accounts/AddExistingAccountSheet.swift
+++ b/Nostur/Accounts/AddExistingAccountSheet.swift
@@ -283,6 +283,10 @@ struct AddExistingAccountSheet: View {
                         NIP46SecretManager.shared.deleteSecret(account: account)
                         viewContext.delete(account)
                     }
+                    // Stop showing the full-screen spinner, otherwise the user is stuck on an
+                    // infinite CenteredProgressView() with no feedback. Returning to the form also
+                    // surfaces bunkerManager.error and lets them retry.
+                    loading = false
                 }
             })
             .onAppear {


### PR DESCRIPTION
## What

If the NIP-46 bunker connection fails while the add-account sheet is showing (bad bunker URL, unreachable relay), `loading` stays `true` and the user is stuck on an infinite `CenteredProgressView` with no feedback. The existing `loading = false` only runs in `onAppear`, so it never fires for a mid-session failure.

This resets `loading` in the `.error` branch, returning to the form so `bunkerManager.error` is visible and the user can retry.

One file, +4 lines. Running with this locally — the error path now lands back on the form with the error shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)