### PR TITLE
Show a media thumbnail in notification rows instead of the raw URL

### DIFF
--- a/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalMediaThumbnail.swift
+++ b/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalMediaThumbnail.swift
@@ -1,0 +1,66 @@
+//
+//  MinimalMediaThumbnail.swift
+//  Nostur
+//
+//  Created by Claude on 10/06/2026.
+//
+
+import SwiftUI
+import Nuke
+import NukeUI
+
+// Small thumbnail for notification rows (Reactions/Reposts/Zaps), so it's visible at a
+// glance which media post a notification is about.
+// Must stay passive: no gestures and no ZoomableItem here, the whole row is the tap target.
+struct MinimalMediaThumbnail: View {
+    @Environment(\.theme) private var theme
+    public let url: URL
+    public var extraCount: Int = 0 // shows "+N" badge when the post has more media than this thumbnail
+    public var isVideo: Bool = false
+
+    static let SIZE: CGFloat = 48.0
+
+    var body: some View {
+        theme.background
+            .frame(width: Self.SIZE, height: Self.SIZE)
+            .overlay {
+                if isVideo {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(Color.gray)
+                }
+                else {
+                    LazyImage(
+                        request: ImageRequest(
+                            url: url,
+                            processors: [.resize(size: CGSize(width: Self.SIZE, height: Self.SIZE), upscale: true)],
+                            options: SettingsStore.shared.lowDataMode ? [.returnCacheDataDontLoad] : [],
+                            userInfo: [.scaleKey: UIScreen.main.scale]
+                        )
+                    ) { state in
+                        if let image = state.image {
+                            image
+                        }
+                        else {
+                            Image(systemName: "photo")
+                                .foregroundColor(Color.gray)
+                        }
+                    }
+                    .pipeline(ImageProcessing.shared.content)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(alignment: .bottomTrailing) {
+                if extraCount > 0 {
+                    Text("+\(extraCount)")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.black.opacity(0.65))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .padding(3)
+                }
+            }
+    }
+}

--- a/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalNoteTextRenderView.swift
+++ b/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalNoteTextRenderView.swift
@@ -8,15 +8,58 @@
 import SwiftUI
 
 struct MinimalNoteTextRenderView: View {
-    
+
     @ObservedObject var nrPost: NRPost
     var lineLimit:Int = 10
     var textColor: Color = .primary.opacity(0.5)
-    
+    var showMediaThumbnail: Bool = false // notification rows: leading thumbnail instead of raw media urls in text
+
+    private var videoContents: [MediaContent] {
+        nrPost.contentElements.compactMap { element in
+            if case .video(let mediaContent) = element { return mediaContent }
+            return nil
+        }
+    }
+
+    // plainText without the media urls that the thumbnail already represents
+    private var snippet: String {
+        var text = nrPost.plainText
+        for galleryItem in nrPost.galleryItems {
+            text = text.replacingOccurrences(of: galleryItem.url.absoluteString, with: "")
+        }
+        for video in videoContents {
+            text = text.replacingOccurrences(of: video.url.absoluteString, with: "")
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     var body: some View {
+        if showMediaThumbnail, let firstGalleryItem = nrPost.galleryItems.first {
+            HStack(alignment: .top, spacing: 10) {
+                MinimalMediaThumbnail(url: firstGalleryItem.url, extraCount: (nrPost.galleryItems.count - 1) + videoContents.count)
+                    .padding(.vertical, 5) // same vertical padding as the text, so the image top aligns with the first text line
+                if snippet.isEmpty { Spacer() } else { textView(snippet) }
+            }
+            .contentShape(Rectangle()) // keep the area next to a caption-less thumbnail tappable for the row's tap gesture
+        }
+        else if showMediaThumbnail, let firstVideo = videoContents.first {
+            HStack(alignment: .top, spacing: 10) {
+                MinimalMediaThumbnail(url: firstVideo.url, extraCount: videoContents.count - 1, isVideo: true)
+                    .padding(.vertical, 5) // same vertical padding as the text, so the image top aligns with the first text line
+                if snippet.isEmpty { Spacer() } else { textView(snippet) }
+            }
+            .contentShape(Rectangle()) // keep the area next to a caption-less thumbnail tappable for the row's tap gesture
+        }
+        else {
+            textView(nrPost.plainText)
+        }
+    }
+
+    @ViewBuilder
+    private func textView(_ plainText: String) -> some View {
         VStack(alignment: .leading) {
             if #available(iOS 16.0, *) {
-                Text(nrPost.plainText)//.border(.cyan)
+                Text(plainText)//.border(.cyan)
                     .lineLimit(lineLimit, reservesSpace: false)
                     .multilineTextAlignment(TextAlignment.leading)
                     .foregroundColor(textColor)
@@ -25,7 +68,7 @@ struct MinimalNoteTextRenderView: View {
                     .padding(.vertical, 5)
             }
             else {
-                Text(nrPost.plainText)//.border(.cyan)
+                Text(plainText)//.border(.cyan)
                     .lineLimit(lineLimit)
                     .multilineTextAlignment(TextAlignment.leading)
                     .foregroundColor(textColor)

--- a/Nostur/Screens/MainTabs/Notifications/Reposts/NoteMinimalContentView.swift
+++ b/Nostur/Screens/MainTabs/Notifications/Reposts/NoteMinimalContentView.swift
@@ -15,7 +15,7 @@ struct NoteMinimalContentView: View {
         VStack (alignment: .leading) {
             HStack(alignment: .top) {
                 VStack(alignment:.leading, spacing: 3) {
-                    MinimalNoteTextRenderView(nrPost: nrPost, lineLimit: lineLimit)
+                    MinimalNoteTextRenderView(nrPost: nrPost, lineLimit: lineLimit, showMediaThumbnail: true)
                     
                     if let quoteNRPost = nrPost.firstQuote {
                         MinimalQuotedNoteFragment(nrPost: quoteNRPost)

--- a/Nostur/Screens/MainTabs/Notifications/Reposts/NotificationsReposts.swift
+++ b/Nostur/Screens/MainTabs/Notifications/Reposts/NotificationsReposts.swift
@@ -54,7 +54,7 @@ struct NotificationsReposts: View {
                                         .onAppear { self.enqueue(nrPost) }
                                         .onDisappear { self.dequeue(nrPost) }
                                     if let firstQuote = nrPost.firstQuote {
-                                        MinimalNoteTextRenderView(nrPost: firstQuote, lineLimit: 5)
+                                        MinimalNoteTextRenderView(nrPost: firstQuote, lineLimit: 5, showMediaThumbnail: true)
                                             .onTapGesture {
                                                 navigateTo(firstQuote, context: containerID)
                                             }


### PR DESCRIPTION
## What

When someone reacts to, reposts, or zaps a media post, the notification row currently renders the raw content text — so blossom/media URLs show up as multi-line URL strings, and it's hard to tell at a glance which photo people are responding to.

This replaces the URL with a small (48pt) thumbnail at the start of the snippet: image first, caption text to its right. Multi-image posts show one thumbnail with a "+N" badge instead of a gallery, so busy notification tabs stay calm. Videos get a play-icon placeholder (no frame extraction in list rows). The media URLs are stripped from the snippet text via exact string match against the already-parsed `galleryItems`/`contentElements` — no regex.

All three tabs (Reactions, Reposts, Zaps) get this through the shared `MinimalNoteTextRenderView` behind an opt-in `showMediaThumbnail` flag, defaulting to false — so the other users of that view (video overlays, private notes, post mentions, quoted fragments) are bit-identical to before. The thumbnail is passive (no gesture, not a `ZoomableItem`), so row tap behavior is unchanged. Loading goes through the existing Nuke pipeline at thumbnail size, same cost class as the PFPs these rows already load.

One new file (`MinimalMediaThumbnail.swift`), +49/−6 in the shared renderer, one-line opt-ins at two call sites. Tested on device across all three tabs.

## Before / after

| Before | After |
|---|---|
| <img width="590" height="1278" alt="Screenshot 2026-06-10 at 08 12 11" src="https://github.com/user-attachments/assets/a42dc1a7-2d9c-423a-9431-9a9ed03a5a4b" />| <img width="590" height="1278" alt="Screenshot 2026-06-10 at 13 01 33" src="https://github.com/user-attachments/assets/c1a65d3e-a969-48f9-b38c-b8ac9c3e0238" /> |

## Separate question: interest in making the notification tabs more uniform?

While working in this area I noticed each notification tab hand-rolls its own row layout, and they've drifted apart: zaps rows are top-aligned while reactions rows are centered, the timestamp lives in a different place per tab (inside `ZapsForThisNote` for zaps, on the `Box` overlay for reposts, absent on reactions), and the overlapping PFP strips use `.offset` inside a `ZStack`, which takes no layout space — so with ~10 PFPs the strip silently paints over whatever sits to its right (you can see it run under the timestamp today).

Would you be open to a follow-up PR that extracts a shared `NotificationRow` container handling the common structure (content + timestamp + optional media thumbnail) so the tabs stay consistent by construction? Happy to do the work and keep it review-friendly — but it's your call on whether that refactor is welcome, so asking before writing it. This PR intentionally doesn't touch any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)