### PR TITLE
Fix failed bunker connect deleting a pre-existing account

### DIFF
--- a/Nostur/Accounts/AddExistingAccountSheet.swift
+++ b/Nostur/Accounts/AddExistingAccountSheet.swift
@@ -36,7 +36,12 @@ struct AddExistingAccountSheet: View {
     @ObservedObject private var bunkerManager = RemoteSignerManager.shared
     
     @State private var loading = false
-    
+
+    // Whether the bunker account currently connecting was created by this add attempt.
+    // addExistingBunkerAccount() reuses an existing CloudAccount when the bunker URI pubkey
+    // matches, and a failed connect must never delete an account the user already had.
+    @State private var didCreateNewBunkerAccount = false
+
     private var shouldDisableAddButton: Bool {
         isNsecbunkerKey && (bunkerManager.state == .connecting || bunkerManager.invalidRelayAddress)
     }
@@ -279,7 +284,11 @@ struct AddExistingAccountSheet: View {
                     }
                 }
                 else if bunkerState == .error {
-                    if let account = bunkerManager.account {
+                    // Only clean up an account this add attempt created. bunkerManager.account can
+                    // be a pre-existing account (reused row when the bunker URI pubkey matched), and
+                    // deleting it here would destroy the user's account and its NIP-46 session key,
+                    // with both deletions syncing to other devices (CloudKit + iCloud Keychain).
+                    if didCreateNewBunkerAccount, let account = bunkerManager.account {
                         NIP46SecretManager.shared.deleteSecret(account: account)
                         viewContext.delete(account)
                     }
@@ -428,6 +437,7 @@ struct AddExistingAccountSheet: View {
     private func addExistingBunkerAccount(pubkey: String, token: String? = nil) {
         if let existingAccount = (try? CloudAccount.fetchAccount(publicKey: pubkey, context: viewContext)) {
             existingAccount.flagsSet.insert("full_account")
+            didCreateNewBunkerAccount = false
             bunkerManager.connect(existingAccount, token: token)
             return
         }
@@ -435,6 +445,7 @@ struct AddExistingAccountSheet: View {
         let account = CloudAccount(context: viewContext)
         account.flags = "full_account"
         account.createdAt = Date()
+        didCreateNewBunkerAccount = true
         
         // NIP-46 user-pubkey. This one can change after we call get_public_key on bunker
         account.publicKey = pubkey


### PR DESCRIPTION
## Symptom

Adding a remote-signer (bunker://) account that fails to connect — 15s timeout or connection error — can delete an account the user already has, together with its NIP-46 session key. Real-world report: adding a second Clave bunker account wiped the existing account. The row deletion syncs via CloudKit and the keychain deletion via iCloud Keychain, so the account disappears from all devices.

## Mechanism

- `addExistingBunkerAccount()` reuses an existing `CloudAccount` when the bunker URI pubkey matches one we already have (`CloudAccount.fetchAccount` at the top), so `bunkerManager.account` can point at a pre-existing account.
- The `.error` branch of `.onValueChange(bunkerManager.state)` then runs `NIP46SecretManager.deleteSecret(account:)` + `viewContext.delete(account)` on it.
- This branch was unreachable for the bunker path until 00c33fe0 ("fix state change not handled because dismissed too soon"): previously `onDismiss?()` tore the sheet down immediately, so the handler never fired. Keeping the sheet alive (correct for handling the state changes) armed this cleanup path, which is only safe for an account the add attempt itself created.

This is easy to hit with signers that answer in the background (Clave answers via NSE/APNs, which can exceed the 15s window) or with a re-pasted stale bunker URI for an account that already exists.

## Fix

Track whether the connecting account was created by this add attempt (`didCreateNewBunkerAccount`) and only delete the account + session secret in that case. A failed connect on a reused, pre-existing account now just surfaces the error and allows retry.

## Tested

- Simulator: add a read-only account, then paste a `bunker://` URI with the same pubkey and an unreachable relay. On current main the account is deleted after the timeout; with this fix it survives.
- Adding multiple Clave bunker accounts works again end-to-end; failed adds are retryable with nothing deleted.

## Out of scope (follow-up candidates)

- A failed connect on a reused account still leaves `isNC = true`/`ncClientPubkey_` set by `connect()` (pre-existing).
- `NIP46SecretManager.generateKeysForAccount` returns a newly generated pubkey even when it kept the previously stored key, so `ncClientPubkey_` can record a key that was never stored (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)