### PR TITLE
Fix guest account auto-login on fresh install

### DIFF
--- a/Nostur/AccountsState.swift
+++ b/Nostur/AccountsState.swift
@@ -67,7 +67,10 @@ class AccountsState: ObservableObject {
                 }
             }
         }
-        else if let nextAccount = accounts.sorted(by: { $0.lastLoginAt < $1.lastLoginAt }).last, loadAnyAccount { // can't find account, change to last active account
+        // can't find account, change to last active account. Never auto-activate the guest account
+        // here: it is pre-created as a prefetch on first launch (initializeGuestAccount) and should
+        // only become active by explicit user action (same exclusion as Onboarding.onAppear).
+        else if let nextAccount = accounts.sorted(by: { $0.lastLoginAt > $1.lastLoginAt }).first(where: { $0.publicKey != GUEST_ACCOUNT_PUBKEY }), loadAnyAccount {
             Task { @MainActor in
                 changeAccount(nextAccount)
             }


### PR DESCRIPTION
## Symptom

On a fresh install, the welcome screen logs into the guest account by itself, about a second after launch, without any user action.

## Mechanism

- `AppState.initializeGuestAccount` pre-creates the guest `CloudAccount` ~1s after first launch as a prefetch (so "try as guest" is instant) — it was never meant to log in.
- Since 26a38667, the `CloudAccountBgFetchRequest` change handler calls `loadAccountsState(loadAnyAccount: true)` whenever the active pubkey is not among the loaded accounts. On a fresh install the active pubkey is empty, so the guest row's save triggers that fallback, and the `loadAnyAccount` picker in `AccountsState.loadAccountsState` happily selects the guest account.
- The `Onboarding.onAppear` half of the same workaround already excludes `GUEST_ACCOUNT_PUBKEY`, so the FRC-path guest login looks unintended.

## Fix

Apply the same guest exclusion to the `loadAnyAccount` fallback picker. The iCloud-sync workaround keeps working (falls back to the most recently used real account when the active one hasn't synced yet). Explicit guest login (`TryGuestAccountSheet`) and an already-active guest account go through the `activeAccountPublicKey` match instead of this fallback, so they are unaffected.

## Tested

- Simulator, fresh install: welcome screen now stays until the user acts, including across relaunches.
- "Skip and try as guest" still logs into the guest account.
- Existing-account login and account switching unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)