### PR TITLE
Fix NIP-17 DM startup race

### DIFF
--- a/Nostur/DMs/DMsVM.swift
+++ b/Nostur/DMs/DMsVM.swift
@@ -190,6 +190,7 @@ class DMsVM: ObservableObject, Equatable, Hashable {
     // For per account columns: .onAppear/.task of column
     @MainActor
     public func load(force: Bool = false) async {
+        syncMainAccountPubkeyIfNeeded()
         guard !accountPubkey.isEmpty else { return }
         guard force || !ready else { return }
         if let account = AccountsState.shared.accounts.first(where: { $0.publicKey == self.accountPubkey }) {
@@ -335,11 +336,19 @@ class DMsVM: ObservableObject, Equatable, Hashable {
         accountChangedSubscription = receiveNotification(.activeAccountChanged)
             .sink { [weak self] notification in
                 Task { @MainActor in
-                    guard self?.ready ?? false else { return }
                     let account = notification.object as! CloudAccount
+                    guard self?.accountPubkey != account.publicKey || !(self?.ready ?? false) else { return }
                     await self?.reload(accountPubkey: account.publicKey)
                 }
             }
+    }
+
+    @MainActor
+    private func syncMainAccountPubkeyIfNeeded() {
+        guard isMain && accountPubkey.isEmpty else { return }
+        let activeAccountPubkey = AccountsState.shared.activeAccountPublicKey
+        guard !activeAccountPubkey.isEmpty else { return }
+        accountPubkey = activeAccountPubkey
     }
     
     public func loadAfterWoT() {


### PR DESCRIPTION
## Attribution
- This pull request was prepared by Fabian's AI assistant on Fabian's behalf.

## Summary
- let `DMsVM.shared` adopt the active account pubkey lazily if it was initialized before `AccountsState` finished loading
- allow `.activeAccountChanged` to bootstrap the initial DM load when the main DM view model is not ready yet
- avoid redundant reloads when the account pubkey is unchanged and the view model is already ready

## Verification
- Unable to run `xcodebuild` in this environment because only Command Line Tools are installed (`xcodebuild` requires full Xcode and `/Applications/Xcode.app` is not present)
- Verified the change is isolated to `Nostur/DMs/DMsVM.swift` and rebased onto the latest `origin/main`
