### PR TITLE
Add NIP-17 DM reaction sending

### DIFF
--- a/Nostur/DMs/BalloonView.swift
+++ b/Nostur/DMs/BalloonView.swift
@@ -21,6 +21,8 @@ struct BalloonView17: View {
     @Environment(\.availableWidth) private var availableWidth
     
     @State private var showDMSendResult: RecipientResult? = nil
+    @State private var showReactionPicker = false
+    @State private var selectedReactionEmoji = ""
     
     var body: some View {
 #if DEBUG
@@ -95,7 +97,14 @@ struct BalloonView17: View {
                                 vm.quotingNow = nrChatMessage
                             }
                         }
-    //                    Button("React...", systemImage: "smiley") { }
+                        Button("Like", systemImage: "heart") {
+                            Task {
+                                await vm.sendReaction("❤️", to: nrChatMessage)
+                            }
+                        }
+                        Button("React...", systemImage: "face.smiling") {
+                            showReactionPicker = true
+                        }
                     }
                 } label: {
                     Image(systemName: "ellipsis")
@@ -154,6 +163,19 @@ struct BalloonView17: View {
                     dmSentResult: dmSendResult,
                     isOwnRelays: accountPubkey == dmSendResult.recipientPubkey
                 )
+            }
+        }
+        .emojiPicker(
+            isPresented: $showReactionPicker,
+            selectedEmoji: $selectedReactionEmoji,
+            isDismissAfterChoosing: true
+        )
+        .onChange(of: selectedReactionEmoji) { newValue in
+            guard !newValue.isEmpty else { return }
+            let reaction = newValue
+            selectedReactionEmoji = ""
+            Task {
+                await vm.sendReaction(reaction, to: nrChatMessage)
             }
         }
     }

--- a/Nostur/DMs/DMConversationVM.swift
+++ b/Nostur/DMs/DMConversationVM.swift
@@ -505,6 +505,67 @@ class ConversionVM: ObservableObject {
             try await self.sendMessage04(message)
         }
     }
+
+    @MainActor
+    public func sendReaction(_ reactionContent: String, to message: NRChatMessage) async {
+        guard conversationVersion == 17 else { return }
+        guard let privKey = AccountManager.shared.getPrivateKeyHex(pubkey: ourAccountPubkey),
+              let ourkeys = try? NostrEssentials.Keys(privateKeyHex: privKey) else { return }
+
+        let normalizedReaction = reactionContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedReaction.isEmpty else { return }
+
+        guard !message.reactions.contains(where: { $0.authorPubkey == ourAccountPubkey && $0.content == normalizedReaction }) else {
+            return
+        }
+
+        var tags: [Tag] = participants.map { Tag(["p", $0]) }
+        tags.append(Tag(["e", message.id]))
+
+        if SettingsStore.shared.postUserAgentEnabled && !SettingsStore.shared.excludedUserAgentPubkeys.contains(ourAccountPubkey) {
+            tags.append(Tag(["client", NIP89_APP_NAME, NIP89_APP_REFERENCE]))
+        }
+
+        let reactionEvent = NostrEssentials.Event(
+            pubkey: ourAccountPubkey,
+            content: normalizedReaction,
+            kind: 7,
+            created_at: Int(Date().timeIntervalSince1970),
+            tags: tags
+        )
+        let rumorEvent = createRumor(reactionEvent)
+        let rumorNEvent = NEvent.fromNostrEssentialsEvent(rumorEvent)
+
+        message.addReaction(rumorNEvent)
+
+        for receiverPubkey in participants {
+            do {
+                let giftWrap = try createGiftWrap(rumorEvent, receiverPubkey: receiverPubkey, keys: ourkeys)
+                let giftWrapId = giftWrap.fallbackId()
+
+                if receiverPubkey == ourAccountPubkey {
+                    await bg().perform {
+                        _ = Event.saveEvent(event: rumorEvent, wrapId: giftWrapId, context: bg())
+                        MessageParser.shared.pendingOkWrapIds.insert(giftWrapId)
+                    }
+                }
+
+                let relays = await getDMrelays(for: receiverPubkey)
+                let relaysWithFallback = if relays.isEmpty {
+                    await getDMrelays(for: ourAccountPubkey)
+                } else {
+                    relays
+                }
+
+                sendWrappedEventToDMRelays(giftWrap, relays: relaysWithFallback)
+            }
+            catch {
+#if DEBUG
+                L.og.debug("🔴🔴 💌💌 error while trying to wrap reaction \(error)")
+#endif
+            }
+        }
+    }
     
     @MainActor private func sendMessage04(_ message: String) async throws {
         guard let privKey = AccountManager.shared.getPrivateKeyHex(pubkey: ourAccountPubkey) else { throw DMError.PrivateKeyMissing }
@@ -870,6 +931,30 @@ class ConversionVM: ObservableObject {
     public func markAsRead() {
         self.dmState?.markedReadAt_ = Date.now
 //        DataProvider.shared().saveToDisk(.all)
+    }
+
+    private func sendWrappedEventToDMRelays(_ wrappedEvent: NostrEssentials.Event, relays: Set<String>) {
+        for relay in relays {
+            if ConnectionPool.shared.connections[relay] != nil {
+                ConnectionPool.shared.sendMessage(
+                    NosturClientMessage(
+                        clientMessage: NostrEssentials.ClientMessage(type: .EVENT, event: wrappedEvent),
+                        relayType: .WRITE,
+                        nEvent: NEvent.fromNostrEssentialsEvent(wrappedEvent)
+                    ),
+                    relays: [RelayData(read: false, write: true, search: false, auth: false, url: relay, excludedPubkeys: [])]
+                )
+            }
+            else if let msg = NostrEssentials.ClientMessage(type: .EVENT, event: wrappedEvent).json() {
+                Task { @MainActor in
+                    ConnectionPool.shared.sendEphemeralMessage(
+                        msg,
+                        relay: relay,
+                        write: true
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add DM bubble menu actions for quick heart and custom emoji reactions in NIP-17 conversations
- send reactions as private kind 7 giftwrapped events to all conversation participants and save self-wrap locally for DM replay
- optimistically show the chosen reaction immediately and avoid duplicate identical reactions from the current account

## Verification
- started a simulator build after creating a temporary local Config.xcconfig from Config.xcconfig.dist so the project could parse configuration
- stopped the build during long dependency compilation; no immediate errors surfaced from the edited files before termination

## Attribution
- This pull request was prepared by Fabian's AI assistant on Fabian's behalf.

## Initial prompt:
_"Add a feature to Nostur: in the nip17 DM its now possible to see reactions, we need to also add the ability to send reactions in a message. Add it to the menu, or suggest me a better UX if you think that’s easier to integrate. Use the local repo, make a pull request when ready."_