### PR TITLE
Add client metadata to NIP-46 bunker connect (nips#2381)

### DIFF
--- a/Nostur/Nostr/NIP46-NC/RemoteSignerManager.swift
+++ b/Nostur/Nostr/NIP46-NC/RemoteSignerManager.swift
@@ -367,13 +367,16 @@ class RemoteSignerManager: ObservableObject {
             self.connectToBunker(sessionPublicKey: ncRemoteSignerPubkey, relay: self.ncRelay)
         }
         
-        // the connect request, params are remote signer public key (used to be user pubkey) and the bunker provided redemption token
-        let request = if let token {
-            NCRequest(id: "connect-\(UUID().uuidString)", method: "connect", params: [ncRemoteSignerPubkey, token])
-        }
-        else {
-            NCRequest(id: "connect-\(UUID().uuidString)", method: "connect", params: [ncRemoteSignerPubkey])
-        }
+        // the connect request. NIP-46 params: [remote-signer pubkey, optional secret/redemption token,
+        // optional requested perms, optional client metadata]. Client metadata (NIP-46 PR #2381) lets the
+        // remote signer label this connection; it is a display hint only and is not authenticated. An empty
+        // string is passed for requested perms so the metadata occupies the required fourth position.
+        let clientMetadata: String = {
+            let meta = ["name": "Nostur", "url": "https://nostur.com", "image": "https://nostur.com/nostur.png"]
+            guard let data = try? JSONEncoder().encode(meta), let json = String(data: data, encoding: .utf8) else { return "" }
+            return json
+        }()
+        let request = NCRequest(id: "connect-\(UUID().uuidString)", method: "connect", params: [ncRemoteSignerPubkey, token ?? "", "", clientMetadata])
         let encoder = JSONEncoder()
         
         guard let requestJsonData = try? encoder.encode(request) else { state = .error; return }


### PR DESCRIPTION
Adds optional client metadata to the NIP-46 `bunker://` connect flow, implementing [nostr-protocol/nips#2381](https://github.com/nostr-protocol/nips/pull/2381) (approved by fiatjaf and greenart7c3).

## What

The `connect` request now includes an optional 4th param — a JSON-stringified `{name, url, image}` object — so the remote signer can identify and label the client:

```json
["<remote-signer-pubkey>", "<secret>", "", "{\"name\":\"Nostur\",\"url\":\"https://nostur.com\",\"image\":\"https://nostur.com/nostur.png\"}"]
```

The `bunker://` handshake previously gave the client nowhere to describe itself, so bunker pairings showed up nameless on the signer side. `nostrconnect://` already carries these fields; this closes the asymmetry.

## Notes

- **Backward compatible** — it's an optional positional param; signers that read only the first three ignore it. An empty string is passed for requested-perms so the metadata occupies the 4th position, per the spec.
- **Display-only / unauthenticated**, as the spec requires.
- Scope is limited to `RemoteSignerManager.connect`; no change to the existing flow beyond the added param.

## Testing

- Confirmed the outgoing `connect` request carries the metadata.
- Tested end-to-end against a NIP-46 signer that reads `params[3]`: the client name + logo render on the approval prompt, and signing/posting works.
- Builds clean (arm64 iOS Simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
