### PR TITLE
Fix DM refresh after iPhone foreground

### DIFF
--- a/Nostur/AppView.swift
+++ b/Nostur/AppView.swift
@@ -114,6 +114,7 @@ extension AppView {
                     ConnectionPool.shared.connectAll()
                     sendNotification(.scenePhaseActive)
                     FeedsCoordinator.shared.resumeFeeds()
+                    DMsVM.restoreSubscriptions()
                     NotificationsViewModel.restoreSubscriptions()
                     AppState.shared.startTaskTimers()
                     try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
@@ -125,6 +126,7 @@ extension AppView {
                 ConnectionPool.shared.connectAll()
                 sendNotification(.scenePhaseActive)
                 FeedsCoordinator.shared.resumeFeeds()
+                DMsVM.restoreSubscriptions()
                 NotificationsViewModel.restoreSubscriptions()
                 AppState.shared.startTaskTimers()
             }

--- a/Nostur/DMs/DMsVM.swift
+++ b/Nostur/DMs/DMsVM.swift
@@ -301,6 +301,7 @@ class DMsVM: ObservableObject, Equatable, Hashable {
     @MainActor
     public func restoreSubscriptions() {
         guard ready, !ncNotSupported, !accountPubkey.isEmpty else { return }
+        loadConversations(fullReload: true)
         fetchNip04DMs()
         fetchGiftWraps(forceRefresh: true)
     }


### PR DESCRIPTION
## Summary
- restore DM subscriptions when the app becomes active on iPhone and macOS
- reload DM state from Core Data before re-requesting relay-backed DM events
- fix the case where iCloud updates the DM blurb, but the actual DM relay fetch is not re-triggered until app relaunch

## Root cause
The app already refreshes feeds and notifications on foreground, but DMs were not explicitly restored from the app lifecycle path. That meant DM metadata could arrive via iCloud while the relay subscriptions that fetch the actual DM events were only guaranteed on cold start or socket reopen.

## Testing
- `xcodebuild -project Nostur.xcodeproj -scheme Nostur -destination 'generic/platform=iOS' build`
  - blocked locally by missing provisioning profiles for `nostur.com.Nostur` and `nostur.com.Nostur.Share-highlight-with-Nostur`

_Comment posted by Fabian’s AI assistant._
