### PR TITLE
Fix DM foreground recovery when iCloud sync restores only the blurb

### DIFF
--- a/Nostur/AppView.swift
+++ b/Nostur/AppView.swift
@@ -115,6 +115,7 @@ extension AppView {
                     sendNotification(.scenePhaseActive)
                     FeedsCoordinator.shared.resumeFeeds()
                     DMsVM.restoreSubscriptions()
+                    ConversionVM.restoreSubscriptions()
                     NotificationsViewModel.restoreSubscriptions()
                     AppState.shared.startTaskTimers()
                     try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
@@ -127,6 +128,7 @@ extension AppView {
                 sendNotification(.scenePhaseActive)
                 FeedsCoordinator.shared.resumeFeeds()
                 DMsVM.restoreSubscriptions()
+                ConversionVM.restoreSubscriptions()
                 NotificationsViewModel.restoreSubscriptions()
                 AppState.shared.startTaskTimers()
             }

--- a/Nostur/DMs/DMConversationVM.swift
+++ b/Nostur/DMs/DMConversationVM.swift
@@ -44,6 +44,41 @@ struct PendingFileAttachment {
 }
 
 class ConversionVM: ObservableObject {
+    private final class WeakConversionVMBox {
+        weak var value: ConversionVM?
+        
+        init(_ value: ConversionVM) {
+            self.value = value
+        }
+    }
+    
+    @MainActor private static var liveInstances: [ObjectIdentifier: WeakConversionVMBox] = [:]
+    
+    static func restoreSubscriptions() {
+        Task { @MainActor in
+            cleanupLiveInstances()
+            for vm in liveInstances.values.compactMap(\.value) {
+                await vm.restoreSubscriptions()
+            }
+        }
+    }
+    
+    @MainActor
+    private static func register(_ vm: ConversionVM) {
+        cleanupLiveInstances()
+        liveInstances[ObjectIdentifier(vm)] = WeakConversionVMBox(vm)
+    }
+    
+    @MainActor
+    private static func unregister(_ id: ObjectIdentifier) {
+        liveInstances.removeValue(forKey: id)
+    }
+    
+    @MainActor
+    private static func cleanupLiveInstances() {
+        liveInstances = liveInstances.filter { $0.value.value != nil }
+    }
+    
     public var participants: Set<String> // all participants (including sender)
     public var ourAccountPubkey: String {
         didSet {
@@ -126,6 +161,12 @@ class ConversionVM: ObservableObject {
         self.yearIdFormatter = yearIdFormatter
         
         self.parentDMsVM = parentDMsVM
+        
+        Task { @MainActor [weak self] in
+            if let self {
+                Self.register(self)
+            }
+        }
     }
     
     private var didLoad = false
@@ -231,6 +272,12 @@ class ConversionVM: ObservableObject {
         // newer giftwraps will be fetched from general DMsVM.fetchGiftWraps(), can't query conversation specific with metadata hidden
         self.fetchDMrelays()
         self.listenForNewMessages()
+    }
+    
+    @MainActor
+    public func restoreSubscriptions() async {
+        guard didLoad else { return }
+        await load(force: true)
     }
     
     private func listenForNewMessages() {
@@ -954,6 +1001,13 @@ class ConversionVM: ObservableObject {
                     )
                 }
             }
+        }
+    }
+    
+    deinit {
+        let instanceId = ObjectIdentifier(self)
+        Task { @MainActor in
+            Self.unregister(instanceId)
         }
     }
 }

--- a/Nostur/DMs/DMsVM.swift
+++ b/Nostur/DMs/DMsVM.swift
@@ -302,6 +302,9 @@ class DMsVM: ObservableObject, Equatable, Hashable {
     public func restoreSubscriptions() {
         guard ready, !ncNotSupported, !accountPubkey.isEmpty else { return }
         loadConversations(fullReload: true)
+        fetchDMrelays()
+        ConnectionPool.shared.closeSubscription(sentDMSubscriptionId)
+        ConnectionPool.shared.closeSubscription(receivedDMSubscriptionId)
         fetchNip04DMs()
         fetchGiftWraps(forceRefresh: true)
     }


### PR DESCRIPTION
## Summary
- refresh DM relay discovery when the app becomes active again
- hard-reset and reopen the app-level DM subscriptions before refetching
- reload live DM conversation view models on foreground so open threads also refresh

## Why
The previous foreground fix could restore the iCloud-synced DM blurb without restoring the underlying DM event body on iPhone. This change makes the foreground recovery path restart both the list-level and conversation-level DM fetch flow.

## Testing
- build with: `xcodebuild -project Nostur.xcodeproj -scheme Nostur -destination 'platform=iOS Simulator,name=iPhone 17' build`\n- result: `BUILD SUCCEEDED`\n\n_Comment posted by Fabian’s AI assistant._