### PR TITLE
Improve video preview UX in feeds

### DIFF
--- a/Nostur/Post/ContentRenderer.swift
+++ b/Nostur/Post/ContentRenderer.swift
@@ -193,7 +193,9 @@ struct ContentRenderer: View { // VIEW things
                             url: mediaContent.url,
                             pubkey: nrPost.pubkey,
                             nrPost: nrPost,
-                            autoload: shouldAutoload
+                            metaDimension: mediaContent.dimensions,
+                            autoload: shouldAutoload,
+                            thumbnail: mediaContent.thumbnailUrl ?? nrPost.eventImageUrl
                         )
                         .environment(\.availableWidth, availableWidth + (fullWidth ? 20 : 0))
                         .padding(.horizontal, fullWidth ? -10 : 0)
@@ -261,13 +263,7 @@ struct ContentRenderer: View { // VIEW things
                                 .padding(.vertical, 10)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .overlay(alignment: .center) {
-                                    Image(systemName: "play.fill")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 100, height: 100)
-                                        .opacity(0.8)
-    //                                        .centered()
-                                        .contentShape(Rectangle())
+                                    VideoPlayOverlay(size: 88)
                                 }
                         }
                         else {

--- a/Nostur/Post/NR/NRContentElementBuilder.swift
+++ b/Nostur/Post/NR/NRContentElementBuilder.swift
@@ -56,7 +56,7 @@ class NRContentElementBuilder {
                 else if !matchString.matchingStrings(regex: Self.videoUrlPattern).isEmpty {
                     if let url = URL(string: matchString) {
                         let iMeta: iMetaInfo? = findImeta(fastTags, url: matchString)
-                        result.append(ContentElement.video(MediaContent(url: url, dimensions: iMeta?.size, blurHash: iMeta?.blurHash)))
+                        result.append(ContentElement.video(MediaContent(url: url, dimensions: iMeta?.size, blurHash: iMeta?.blurHash, thumbnailUrl: iMeta?.posterUrl)))
                     }
                     else {
                         result.append(ContentElement.text(NRTextParser.shared.parseText(fastTags: fastTags, event: event, text:matchString, primaryColor: primaryColor)))
@@ -342,6 +342,7 @@ struct MediaContent: Hashable {
     var url: URL
     var dimensions: CGSize?
     var blurHash: String?
+    var thumbnailUrl: URL?
     
     var aspect: CGFloat {
         if let dimensions {
@@ -388,6 +389,7 @@ private func getTagValues(_ tag: FastTag) -> [String?] {
 struct iMetaInfo {
     var size: CGSize?
     var blurHash: String?
+    var posterUrl: URL? = nil
     
     var aspect: CGFloat? {
         if let size {
@@ -449,8 +451,17 @@ func iMetaFromFastTag(_ fastTag: FastTag) -> iMetaInfo? {
         }
     }
     
-    if blurHash != nil || size != nil {
-        return iMetaInfo(size: size, blurHash: blurHash)
+    var posterUrl: URL?
+    for value in getTagValues(fastTag) {
+        guard let value = value else { continue }
+        let parts = value.split(separator: " ", maxSplits: 1)
+        if parts.count == 2 && String(parts[0]) == "image" {
+            posterUrl = URL(string: String(parts[1]))
+        }
+    }
+    
+    if blurHash != nil || size != nil || posterUrl != nil {
+        return iMetaInfo(size: size, blurHash: blurHash, posterUrl: posterUrl)
     }
     
     return nil

--- a/Nostur/Post/NXContentRenderer.swift
+++ b/Nostur/Post/NXContentRenderer.swift
@@ -219,13 +219,7 @@ struct NXContentRenderer: View { // VIEW things
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .id(index)
                                 .overlay(alignment: .center) {
-                                    Image(systemName: "play.fill")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 100, height: 100)
-                                        .opacity(0.8)
-    //                                        .centered()
-                                        .contentShape(Rectangle())
+                                    VideoPlayOverlay(size: 88)
                                 }
                         }
                         else {

--- a/Nostur/Post/Video/EmbeddedVideoView.swift
+++ b/Nostur/Post/Video/EmbeddedVideoView.swift
@@ -22,17 +22,35 @@ struct EmbeddedVideoView: View {
     public let autoload: Bool
     public var thumbnail: URL?
     
+    private var effectiveAspect: CGFloat {
+        if let metaDimension, metaDimension.width > 0, metaDimension.height > 0 {
+            return metaDimension.width / metaDimension.height
+        }
+        return vm.aspect
+    }
+    
+    private var frameHeight: CGFloat {
+        availableHeight ?? (availableWidth / effectiveAspect)
+    }
+    
+    private var thumbnailAspect: CGFloat {
+        if let metaDimension, metaDimension.width > 0, metaDimension.height > 0 {
+            return metaDimension.width / metaDimension.height
+        }
+        return 16 / 9
+    }
+    
     var body: some View {
         switch vm.viewState {
         case .initial:
             theme.background.opacity(0.7)
-                .frame(width: availableWidth, height: (availableHeight ?? (availableWidth / vm.aspect)))
+                .frame(width: availableWidth, height: frameHeight)
                 .overlay {
                     if let thumbnail {
                         MediaContentView(
                             galleryItem: GalleryItem(url: thumbnail),
                             availableWidth: availableWidth,
-                            placeholderAspect: 16/9,
+                            placeholderAspect: thumbnailAspect,
                             maxHeight: DIMENSIONS.MAX_MEDIA_ROW_HEIGHT,
                             contentMode: .fit,
                             autoload: autoload
@@ -44,17 +62,17 @@ struct EmbeddedVideoView: View {
                     ProgressView()
                 }
                 .onAppear {
-                    vm.load(url, nrPost: nrPost, autoLoad: autoload)
+                    vm.load(url, nrPost: nrPost, autoLoad: autoload, metaDimensions: metaDimension, availableWidth: availableWidth, availableHeight: availableHeight ?? DIMENSIONS.MAX_MEDIA_ROW_HEIGHT)
                 }
         case .loading(let percentage), .paused(let percentage):
             theme.background.opacity(0.7)
-                .frame(width: availableWidth, height: (availableHeight ?? (availableWidth / vm.aspect)))
+                .frame(width: availableWidth, height: frameHeight)
                 .overlay {
                     if let thumbnail {
                         MediaContentView(
                             galleryItem: GalleryItem(url: thumbnail),
                             availableWidth: availableWidth,
-                            placeholderAspect: 16/9,
+                            placeholderAspect: thumbnailAspect,
                             maxHeight: DIMENSIONS.MAX_MEDIA_ROW_HEIGHT,
                             contentMode: .fit,
                             autoload: autoload
@@ -78,14 +96,14 @@ struct EmbeddedVideoView: View {
                     }
                     else {
                         vm.viewState = .loading(vm.downloadProgress)
-                        vm.load(url, nrPost: nrPost, autoLoad: autoload, loadAnyway: true)
+                        vm.load(url, nrPost: nrPost, autoLoad: autoload, metaDimensions: metaDimension, availableWidth: availableWidth, availableHeight: availableHeight ?? DIMENSIONS.MAX_MEDIA_ROW_HEIGHT, loadAnyway: true)
                     }
                 }
                 .overlay {
                     if case .paused(_) = vm.viewState {
                         Button("Resume") {
                             vm.viewState = .loading(vm.downloadProgress)
-                            vm.load(url, nrPost: nrPost, autoLoad: autoload, loadAnyway: true)
+                            vm.load(url, nrPost: nrPost, autoLoad: autoload, metaDimensions: metaDimension, availableWidth: availableWidth, availableHeight: availableHeight ?? DIMENSIONS.MAX_MEDIA_ROW_HEIGHT, loadAnyway: true)
                         }
                     }
                 }
@@ -136,12 +154,12 @@ struct EmbeddedVideoView: View {
                 
         case .loadedFirstFrame(let firstFrame):
             theme.background.opacity(0.7)
-                .frame(width: availableWidth, height: (availableHeight ?? (availableWidth / vm.aspect)))
+                .frame(width: availableWidth, height: frameHeight)
                 .overlay {
                     Image(uiImage: firstFrame.uiImage)
                         .resizable()
                         .scaledToFit()
-                        .frame(width: availableWidth, height: (availableHeight ?? (availableWidth / vm.aspect)))
+                        .frame(width: availableWidth, height: frameHeight)
                         .overlay(alignment: .bottomLeading) {
                             if let durationString = firstFrame.durationString {
                                 Text(durationString)
@@ -155,13 +173,7 @@ struct EmbeddedVideoView: View {
                 }
                 .overlay(alignment: .center) {
                     if vm.downloadProgress == 0 {
-                        Image(systemName: "play.fill")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 90, height: 90)
-                            .opacity(0.8)
-                            .foregroundColor(theme.accent)
-                            .contentShape(Rectangle())
+                        VideoPlayOverlay(size: 88, accentColor: theme.accent)
                             .onTapGesture {
                                 vm.startPlaying()
                             }
@@ -180,7 +192,7 @@ struct EmbeddedVideoView: View {
                 }
         case .playingInPIP:
             Color.black
-                .frame(width: availableWidth, height: vm.isAudio ? 75.0 : (availableHeight ?? (availableWidth / vm.aspect)))
+                .frame(width: availableWidth, height: vm.isAudio ? 75.0 : frameHeight)
                 .overlay {
                     Image(systemName: "pip")
                         .resizable()
@@ -196,7 +208,7 @@ struct EmbeddedVideoView: View {
                 }
         case .noPreviewFound(let videoUrlString):
             theme.background.opacity(0.7)
-                .frame(width: availableWidth, height: vm.isAudio ? 75.0 : (availableHeight ?? (availableWidth / vm.aspect)))
+                .frame(width: availableWidth, height: vm.isAudio ? 75.0 : frameHeight)
                 .overlay {
                     if SettingsStore.shared.lowDataMode {
                         Text(videoUrlString)
@@ -207,7 +219,7 @@ struct EmbeddedVideoView: View {
                         MediaContentView(
                             galleryItem: GalleryItem(url: thumbnail),
                             availableWidth: availableWidth,
-                            placeholderAspect: 16/9,
+                            placeholderAspect: thumbnailAspect,
                             maxHeight: DIMENSIONS.MAX_MEDIA_ROW_HEIGHT,
                             contentMode: .fit,
                             autoload: autoload
@@ -218,13 +230,7 @@ struct EmbeddedVideoView: View {
                 }
                 .overlay {
                     if vm.downloadProgress == 0 {
-                        Image(systemName:"play.fill")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 90, height: 90)
-                            .opacity(0.8)
-                            .foregroundColor(theme.accent)
-                            .contentShape(Rectangle())
+                        VideoPlayOverlay(size: 88, accentColor: theme.accent)
                             .onTapGesture {
                                 vm.startPlaying()
                             }
@@ -255,6 +261,29 @@ struct EmbeddedVideoView: View {
         default:
             Text("📽️")
         }
+    }
+}
+
+struct VideoPlayOverlay: View {
+    var size: CGFloat = 88
+    var accentColor: Color = .white
+    
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    Circle()
+                        .strokeBorder(Color.white.opacity(0.35), lineWidth: 1)
+                }
+                .shadow(color: .black.opacity(0.18), radius: 16, y: 8)
+            Image(systemName: "play.fill")
+                .font(.system(size: size * 0.34, weight: .semibold))
+                .foregroundStyle(accentColor)
+                .offset(x: size * 0.04)
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
     }
 }
 

--- a/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalMediaThumbnail.swift
+++ b/Nostur/Screens/MainTabs/Notifications/Reposts/MinimalMediaThumbnail.swift
@@ -25,9 +25,7 @@ struct MinimalMediaThumbnail: View {
             .frame(width: Self.SIZE, height: Self.SIZE)
             .overlay {
                 if isVideo {
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 20))
-                        .foregroundColor(Color.gray)
+                    VideoPlayOverlay(size: 22, accentColor: .white)
                 }
                 else {
                     LazyImage(


### PR DESCRIPTION
## Summary
- use `imeta` poster images and dimensions for inline video previews
- keep portrait videos in their correct full-width aspect before first-frame extraction finishes
- replace the dated raw play glyph with a softer modern play badge in feed and notification previews

## Why
Issue #38 called out three separate UX problems that are really the same thing: video previews were not respecting the metadata users already publish. Vertical videos could start in a generic landscape frame, posts with poster images could still look empty until first-frame extraction succeeded, and the play affordance felt old.

This change makes the preview state feel intentional immediately, even before the actual video frame is cached.

## Testing
- attempted: `xcodebuild -project Nostur.xcodeproj -scheme Nostur -destination 'platform=iOS Simulator,name=iPhone 17' build`
- note: the fresh worktree needed a local `Config.xcconfig` copied from `Config.xcconfig.dist` before Xcode would start building
- result: the build progressed deep into app-target compilation without surfacing errors from the touched files before I stopped the long-running full dependency compile

_Comment posted by Fabian’s AI assistant._
