### PR TITLE
Add QR scanning to custom NWC setup

### DIFF
--- a/Nostur/Info.plist
+++ b/Nostur/Info.plist
@@ -61,6 +61,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Nostur uses the camera to scan QR codes and capture photos.</string>
 	<key>TENOR_API_KEY</key>
 	<string>$(TENOR_API_KEY)</string>
 	<key>TENOR_CLIENT_KEY</key>

--- a/Nostur/Zaps/NIP47-NWC/CustomNWCConnectSheet.swift
+++ b/Nostur/Zaps/NIP47-NWC/CustomNWCConnectSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import NostrEssentials
+import UIKit
 
 struct CustomNWCConnectSheet: View {
     @Environment(\.theme) private var theme
@@ -20,6 +21,7 @@ struct CustomNWCConnectSheet: View {
     @State var tryingConnection = false
     @State var nwcErrorMessage = ""
     @State var connectionTimeout:Timer? = nil
+    @State var showQRScanner = false
     
     var validUri: Bool {
         if let _ = try? NWCURI(string: nwcUri) {
@@ -70,28 +72,50 @@ struct CustomNWCConnectSheet: View {
                 
                 TextField("", text: $nwcUri, prompt: Text(verbatim: "nostrwalletconnect:..."))
                     .textFieldStyle(.roundedBorder)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
                     .padding(.top, 0)
                     .padding(.horizontal, 10)
                 
+                HStack {
+                    if canScanQRCode {
+                        Button(String(localized: "Scan QR", comment: "Button to scan a QR code for Nostr Wallet Connect setup"), systemImage: "qrcode.viewfinder") {
+                            showQRScanner = true
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    
+                    Button(String(localized: "Paste", comment: "Button to paste a Nostr Wallet Connect URI from the clipboard"), systemImage: "doc.on.clipboard") {
+                        pasteNWCURIFromClipboard()
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.horizontal, 10)
+                
                 if !nwcErrorMessage.isEmpty {
                     Text(nwcErrorMessage).fontWeight(.bold).foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 10)
+                }
+                
+                if !nwcErrorMessage.isEmpty && !awaitingConnectionId.isEmpty {
                     Button("Try to use anyway") {
                         DispatchQueue.main.async {
                             ss.activeNWCconnectionId = awaitingConnectionId
                             nwcConnectSuccess = true
                         }
                     }
+                    .buttonStyle(.bordered)
+                }
+                
+                if !tryingConnection {
+                    Button(String(localized:"Connect wallet", comment: "Button to connect a wallet to Nostur")) { startNWC() }
+                        .buttonStyle(NRButtonStyle(style: .borderedProminent))
+                        .disabled(!validUri)
                 }
                 else {
-                    if !tryingConnection {
-                        Button(String(localized:"Connect wallet", comment: "Button to connect a wallet to Nostur")) { startNWC() }
-                            .buttonStyle(NRButtonStyle(style: .borderedProminent))
-                            .disabled(!validUri)
-                    }
-                    else {
-                        ProgressView()
-                            .padding()
-                    }
+                    ProgressView()
+                        .padding()
                 }
                 
             }
@@ -122,6 +146,14 @@ struct CustomNWCConnectSheet: View {
                 ss.activeNWCconnectionId = ""
             }
         }
+        .onDisappear {
+            cancelConnectionTimeout()
+        }
+        .onChange(of: nwcUri) { _ in
+            if !nwcErrorMessage.isEmpty {
+                nwcErrorMessage = ""
+            }
+        }
         .onReceive(receiveNotification(.nwcInfoReceived)) { notification in
             // Here we received the info event from the NWC relay
             let nwcInfoNotification = notification.object as! NWCInfoNotification
@@ -130,6 +162,7 @@ struct CustomNWCConnectSheet: View {
                 if let _ = NWCConnection.fetchConnection(awaitingConnectionId, context: bg()) {
                     if nwcInfoNotification.methods.split(separator: " ").map({ String($0) }).contains("pay_invoice") {
                         DispatchQueue.main.async {
+                            finishConnectionAttempt()
                             ss.activeNWCconnectionId = awaitingConnectionId
                             nwcConnectSuccess = true
                         }
@@ -137,13 +170,18 @@ struct CustomNWCConnectSheet: View {
                     // NIP47 spec says to uses space separator, but Alby uses comma.
                     else if nwcInfoNotification.methods.split(separator: ",").map({ String($0) }).contains("pay_invoice") {
                         DispatchQueue.main.async {
+                            finishConnectionAttempt()
                             ss.activeNWCconnectionId = awaitingConnectionId
                             nwcConnectSuccess = true
                         }
                     }
                     else {
                         L.og.error("⚡️ NWC custom connection, does not support pay_invoice")
-                        nwcErrorMessage = String(localized:"This NWC connection does not support payments", comment: "Error message during NWC setup")
+                        DispatchQueue.main.async {
+                            tryingConnection = false
+                            cancelConnectionTimeout()
+                            nwcErrorMessage = String(localized:"This NWC connection does not support payments", comment: "Error message during NWC setup")
+                        }
                     }
                     DataProvider.shared().saveToDiskNow(.bgContext)
                 }
@@ -152,22 +190,35 @@ struct CustomNWCConnectSheet: View {
                 }
             }
         }
+        .sheet(isPresented: $showQRScanner) {
+            NWCQRScannerSheet { scannedValue in
+                importNWCURI(scannedValue, autoConnect: true)
+            }
+            .presentationBackgroundCompat(theme.listBackground)
+        }
     }
     
     func startNWC() {
-        guard let nwc = try? NWCURI(string: nwcUri),
+        let normalizedUri = normalizeNWCURI(nwcUri)
+        nwcUri = normalizedUri
+        
+        guard let nwc = try? NWCURI(string: normalizedUri),
               let secret = nwc.secret,
               let relay = nwc.relay,
               let walletPubkey = nwc.walletPubkey
         else {
+            tryingConnection = false
             nwcErrorMessage = String(localized:"Problem parsing NWC connection URI", comment:"Error message during NWC setup")
             return
         }
+        nwcErrorMessage = ""
+        cancelConnectionTimeout()
         
         bg().perform {
             guard let c = NWCConnection.createCustomConnection(context: bg(), secret: secret) else {
                 L.og.error("Problem handling secret in NWCConnection.createCustomConnection")
                 DispatchQueue.main.async {
+                    tryingConnection = false
                     nwcErrorMessage = String(localized: "Could not parse secret from NWC connection URI", comment: "Error message during NWC setup")
                 }
                 return
@@ -207,10 +258,11 @@ struct CustomNWCConnectSheet: View {
             }
         }
         
-        guard connectionTimeout == nil else { return }
         connectionTimeout?.invalidate()
         connectionTimeout = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: false, block: { _ in
+            tryingConnection = false
             nwcErrorMessage = String(localized:"Could not fetch NWC info event from \(relay)", comment:"Error message during NWC setup")
+            connectionTimeout = nil
         })
     }
     
@@ -228,6 +280,69 @@ struct CustomNWCConnectSheet: View {
         if !ss.activeNWCconnectionId.isEmpty {
             NWCConnection.delete(ss.activeNWCconnectionId, context: DataProvider.shared().viewContext)
         }
+    }
+    
+    private var canScanQRCode: Bool {
+#if targetEnvironment(macCatalyst)
+        false
+#else
+        true
+#endif
+    }
+    
+    private func pasteNWCURIFromClipboard() {
+        guard let clipboardText = UIPasteboard.general.string, !clipboardText.isEmpty else {
+            nwcErrorMessage = String(localized: "Clipboard does not contain a Nostr Wallet Connect URI", comment: "Error shown when the clipboard has no Nostr Wallet Connect URI to paste")
+            return
+        }
+        importNWCURI(
+            clipboardText,
+            autoConnect: false,
+            invalidMessage: String(localized: "Clipboard does not contain a valid Nostr Wallet Connect URI", comment: "Error shown when pasted clipboard text is not a valid Nostr Wallet Connect URI")
+        )
+    }
+    
+    private func importNWCURI(_ rawValue: String, autoConnect: Bool, invalidMessage: String = String(localized: "Scanned QR code is not a valid Nostr Wallet Connect URI", comment: "Error shown when a scanned QR code is not a valid Nostr Wallet Connect URI")) {
+        let normalizedUri = normalizeNWCURI(rawValue)
+        nwcUri = normalizedUri
+        nwcErrorMessage = ""
+        
+        guard validNWCURI(normalizedUri) else {
+            nwcErrorMessage = invalidMessage
+            return
+        }
+        
+        if autoConnect {
+            startNWC()
+        }
+    }
+    
+    private func validNWCURI(_ uri: String) -> Bool {
+        (try? NWCURI(string: uri)) != nil
+    }
+    
+    private func normalizeNWCURI(_ rawValue: String) -> String {
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedValue.lowercased().contains("nostrwalletconnect:") {
+            let lines = trimmedValue
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if let uriLine = lines.first(where: { $0.lowercased().contains("nostrwalletconnect:") }) {
+                return uriLine
+            }
+        }
+        return trimmedValue
+    }
+    
+    private func cancelConnectionTimeout() {
+        connectionTimeout?.invalidate()
+        connectionTimeout = nil
+    }
+    
+    private func finishConnectionAttempt() {
+        tryingConnection = false
+        cancelConnectionTimeout()
     }
 }
 

--- a/Nostur/Zaps/NIP47-NWC/NWCQRScannerSheet.swift
+++ b/Nostur/Zaps/NIP47-NWC/NWCQRScannerSheet.swift
@@ -1,0 +1,374 @@
+//
+//  NWCQRScannerSheet.swift
+//  Nostur
+//
+//  Created for QR-based NWC setup on 21/06/2026.
+//
+
+import SwiftUI
+import AVFoundation
+import UIKit
+
+#if canImport(VisionKit) && !targetEnvironment(macCatalyst)
+import VisionKit
+#endif
+
+struct NWCQRScannerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var cameraAccess: CameraAccessState = .checking
+    @State private var isTorchOn = false
+    
+    let onScan: (String) -> Void
+    
+    var body: some View {
+        ZStack {
+            switch cameraAccess {
+            case .checking:
+                ProgressView(String(localized: "Starting camera…", comment: "Loading message shown while preparing the QR scanner camera"))
+            case .denied:
+                permissionDeniedView
+            case .allowed:
+                scannerContent
+            }
+        }
+        .background(Color.black.ignoresSafeArea())
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(String(localized: "Scan QR", comment: "Navigation title for the Nostr Wallet Connect QR scanner"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", systemImage: "xmark") {
+                    dismiss()
+                }
+            }
+            
+            ToolbarItem(placement: .primaryAction) {
+                if scannerMode == .legacy, LegacyQRCodeScannerViewController.hasTorch {
+                    Button(
+                        isTorchOn
+                        ? String(localized: "Torch Off", comment: "Button to turn off the torch while scanning a QR code")
+                        : String(localized: "Torch On", comment: "Button to turn on the torch while scanning a QR code"),
+                        systemImage: isTorchOn ? "flashlight.off.fill" : "flashlight.on.fill"
+                    ) {
+                        isTorchOn.toggle()
+                    }
+                }
+            }
+        }
+        .task {
+            await ensureCameraAccess()
+        }
+    }
+    
+    @ViewBuilder
+    private var scannerContent: some View {
+        switch scannerMode {
+        case .dataScanner:
+            dataScannerContent
+        case .legacy:
+            LegacyQRCodeScannerView(isTorchOn: $isTorchOn) { scannedValue in
+                handleScan(scannedValue)
+            }
+            .ignoresSafeArea()
+            .safeAreaInset(edge: .bottom) {
+                instructionBanner
+            }
+        case .unavailable:
+            unavailableView
+        }
+    }
+    
+    private var dataScannerContent: AnyView {
+        if #available(iOS 16.0, *) {
+            return AnyView(
+                DataScannerQRCodeView { scannedValue in
+                    handleScan(scannedValue)
+                }
+                .ignoresSafeArea()
+                .safeAreaInset(edge: .bottom) {
+                    instructionBanner
+                }
+            )
+        } else {
+            return AnyView(unavailableView)
+        }
+    }
+    
+    private var instructionBanner: some View {
+        Text(String(localized: "Point your camera at your wallet's NWC QR code", comment: "Instruction shown while scanning a Nostr Wallet Connect QR code"))
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.ultraThinMaterial, in: Capsule())
+            .padding(.bottom, 24)
+    }
+    
+    private var permissionDeniedView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(.white)
+            
+            Text(String(localized: "Camera access is needed to scan an NWC QR code", comment: "Explanation shown when camera permission is denied for the NWC QR scanner"))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.white)
+            
+            Button(String(localized: "Open Settings", comment: "Button to open system settings after camera permission was denied")) {
+                guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(settingsUrl)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(24)
+    }
+    
+    private var unavailableView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "qrcode.viewfinder")
+                .font(.system(size: 40))
+                .foregroundStyle(.white)
+            
+            Text(String(localized: "QR scanning is not available on this device", comment: "Message shown when QR scanning is not available on the current device"))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.white)
+        }
+        .padding(24)
+    }
+    
+    private func handleScan(_ scannedValue: String) {
+        dismiss()
+        onScan(scannedValue)
+    }
+    
+    private var scannerMode: ScannerMode {
+#if targetEnvironment(macCatalyst)
+        .unavailable
+#else
+        guard AVCaptureDevice.default(for: .video) != nil else {
+            return .unavailable
+        }
+        #if canImport(VisionKit)
+        if #available(iOS 16.0, *),
+           DataScannerViewController.isSupported,
+           DataScannerViewController.isAvailable {
+            return .dataScanner
+        }
+        #endif
+        return .legacy
+#endif
+    }
+    
+    private func ensureCameraAccess() async {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            cameraAccess = .allowed
+        case .notDetermined:
+            let accessGranted = await AVCaptureDevice.requestAccess(for: .video)
+            cameraAccess = accessGranted ? .allowed : .denied
+        default:
+            cameraAccess = .denied
+        }
+    }
+}
+
+private extension NWCQRScannerSheet {
+    enum CameraAccessState {
+        case checking
+        case allowed
+        case denied
+    }
+    
+    enum ScannerMode {
+        case dataScanner
+        case legacy
+        case unavailable
+    }
+}
+
+#if canImport(VisionKit) && !targetEnvironment(macCatalyst)
+@available(iOS 16.0, *)
+private struct DataScannerQRCodeView: UIViewControllerRepresentable {
+    let onFound: (String) -> Void
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onFound: onFound)
+    }
+    
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let controller = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .balanced,
+            recognizesMultipleItems: false,
+            isHighFrameRateTrackingEnabled: false,
+            isPinchToZoomEnabled: true,
+            isGuidanceEnabled: true,
+            isHighlightingEnabled: true
+        )
+        controller.delegate = context.coordinator
+        try? controller.startScanning()
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: DataScannerViewController, context: Context) {
+        if !uiViewController.isScanning {
+            try? uiViewController.startScanning()
+        }
+    }
+    
+    static func dismantleUIViewController(_ uiViewController: DataScannerViewController, coordinator: Coordinator) {
+        uiViewController.stopScanning()
+    }
+    
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        private let onFound: (String) -> Void
+        private var didScan = false
+        
+        init(onFound: @escaping (String) -> Void) {
+            self.onFound = onFound
+        }
+        
+        func dataScanner(_ dataScanner: DataScannerViewController, didAdd addedItems: [RecognizedItem], allItems: [RecognizedItem]) {
+            guard !didScan else { return }
+            
+            for item in addedItems {
+                guard case .barcode(let barcode) = item, let payload = barcode.payloadStringValue else { continue }
+                didScan = true
+                onFound(payload)
+                return
+            }
+        }
+    }
+}
+#endif
+
+private struct LegacyQRCodeScannerView: UIViewControllerRepresentable {
+    @Binding var isTorchOn: Bool
+    let onFound: (String) -> Void
+    
+    func makeUIViewController(context: Context) -> LegacyQRCodeScannerViewController {
+        let controller = LegacyQRCodeScannerViewController()
+        controller.onFound = onFound
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: LegacyQRCodeScannerViewController, context: Context) {
+        uiViewController.setTorch(enabled: isTorchOn)
+    }
+    
+    static func dismantleUIViewController(_ uiViewController: LegacyQRCodeScannerViewController, coordinator: ()) {
+        uiViewController.stopScanning()
+    }
+}
+
+private final class LegacyQRCodeScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    static var hasTorch: Bool {
+        AVCaptureDevice.default(for: .video)?.hasTorch ?? false
+    }
+    
+    private let session = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "nostur.nwc.qr.scanner")
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var didConfigureSession = false
+    private var didScan = false
+    
+    var onFound: ((String) -> Void)?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        configureSession()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        startScanning()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopScanning()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+    
+    func startScanning() {
+        sessionQueue.async {
+            guard self.didConfigureSession, !self.session.isRunning else { return }
+            self.session.startRunning()
+        }
+    }
+    
+    func stopScanning() {
+        sessionQueue.async {
+            guard self.session.isRunning else { return }
+            self.session.stopRunning()
+        }
+    }
+    
+    func setTorch(enabled: Bool) {
+        sessionQueue.async {
+            guard let device = AVCaptureDevice.default(for: .video), device.hasTorch else { return }
+            do {
+                try device.lockForConfiguration()
+                device.torchMode = enabled ? .on : .off
+                device.unlockForConfiguration()
+            } catch {
+                L.og.error("Could not toggle NWC QR scanner torch: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    private func configureSession() {
+        sessionQueue.async {
+            guard let videoDevice = AVCaptureDevice.default(for: .video) else { return }
+            do {
+                let videoInput = try AVCaptureDeviceInput(device: videoDevice)
+                
+                self.session.beginConfiguration()
+                
+                if self.session.canAddInput(videoInput) {
+                    self.session.addInput(videoInput)
+                }
+                
+                let metadataOutput = AVCaptureMetadataOutput()
+                if self.session.canAddOutput(metadataOutput) {
+                    self.session.addOutput(metadataOutput)
+                    metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
+                    metadataOutput.metadataObjectTypes = [.qr]
+                }
+                
+                self.session.commitConfiguration()
+                
+                DispatchQueue.main.async {
+                    let previewLayer = AVCaptureVideoPreviewLayer(session: self.session)
+                    previewLayer.videoGravity = .resizeAspectFill
+                    previewLayer.frame = self.view.bounds
+                    self.view.layer.insertSublayer(previewLayer, at: 0)
+                    self.previewLayer = previewLayer
+                }
+                
+                self.didConfigureSession = true
+            } catch {
+                L.og.error("Could not configure NWC QR scanner: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        guard !didScan else { return }
+        
+        for object in metadataObjects {
+            guard let qrObject = object as? AVMetadataMachineReadableCodeObject,
+                  qrObject.type == .qr,
+                  let payload = qrObject.stringValue else { continue }
+            didScan = true
+            stopScanning()
+            onFound?(payload)
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add QR scanning and paste actions to the custom NWC connect sheet
- reuse the existing NWC parsing and connection flow after normalizing scanned or pasted URIs
- add an iOS 16 native scanner path, an iOS 15.5 AVCapture fallback, and clearer retry/permission handling

## Testing
- `xcodebuild -project Nostur.xcodeproj -scheme Nostur -destination 'platform=iOS Simulator,name=iPhone 17' build`

_AI-assisted PR created by Fabian’s AI assistant._