### PR TITLE
Add Indonesian localization

### DIFF
--- a/Highlight with Nostur/InfoPlist.xcstrings
+++ b/Highlight with Nostur/InfoPlist.xcstrings
@@ -17,6 +17,12 @@
             "value" : "Compartir texto seleccionado con Nostur"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan teks yang dipilih dengan Nostur"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41,6 +47,12 @@
             "value" : "Compartir texto seleccionado con Nostur"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan teks yang dipilih dengan Nostur"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60,6 +72,12 @@
           }
         },
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : ""

--- a/Nostur/Localizable.xcstrings
+++ b/Nostur/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "value" : ""
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20,6 +26,12 @@
     "\n%@" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n%@"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "\n%@"
@@ -42,6 +54,12 @@
             "value" : "Esto **borrará** tu:\n - Perfil público nostr\n - Lista pública de seguimiento de nostr"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini akan **menghapus**:\n - Profil nostr publik\n - Daftar berikut nostr Publik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -53,6 +71,12 @@
     " · %@" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " · %@"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " · %@"
@@ -74,6 +98,12 @@
             "value" : "· vía %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "· melalui %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -89,6 +119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "__Código fuente__"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "__Kode sumber__"
           }
         },
         "nl" : {
@@ -108,6 +144,12 @@
             "value" : "_Eliminado por %@_"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Dihapus oleh %@_"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -125,6 +167,12 @@
             "value" : "_Eliminado por el autor_"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Dihapus oleh penulis_"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -140,6 +188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "_Publicación silenciada oculta_"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Postingan yang dibisukan disembunyikan_"
           }
         },
         "nl" : {
@@ -160,6 +214,12 @@
             "value" : "_Publicación eliminada por %@_"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Postingan dihapus oleh %@_"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -176,6 +236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "_Publicación eliminada por el autor_"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Postingan dihapus oleh penulis_"
           }
         },
         "nl" : {
@@ -195,6 +261,12 @@
             "value" : "_Publicación de cuenta bloqueada oculta_"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Postingan dari akun yang diblokir disembunyikan_"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -206,6 +278,12 @@
     "-" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "-"
@@ -227,6 +305,12 @@
             "value" : "- Elija un relay que requiera autenticación para recibir mensajes privados.\n- Puedes elegir relays público, los mensajes serán codificados y anonimizados."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Pilih relay yang memerlukan otentikasi untuk menerima pesan pribadi.\n- Anda dapat memilih relays publik, pesan akan diacak dan dianonimkan."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -238,6 +322,12 @@
     ":%@:" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":%@:"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : ":%@:"
@@ -259,12 +349,24 @@
             "state" : "translated",
             "value" : "!"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "!"
+          }
         }
       }
     },
     "·" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "·"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "·"
@@ -286,6 +388,12 @@
             "value" : "· vía %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "· melalui %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -300,6 +408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(%lld relays deshabilitado)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld relays dinonaktifkan)"
           }
         },
         "nl" : {
@@ -319,6 +433,12 @@
             "value" : "(Re)conecta/Mensajes/Errores"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(Re) menghubungkan/Pesan/Kesalahan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -333,6 +453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(Re)conecta/Mensajes/Errores en el último %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(Re)koneksi/Pesan/Kesalahan di %@ terakhir"
           }
         },
         "nl" : {
@@ -352,6 +478,12 @@
             "value" : "(Tiempo de espera u otro error)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(Waktu habis atau kesalahan lainnya)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -366,6 +498,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "[__Código fuente__](https://github.com/nostur-com/nostur-ios-public)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[__Kode sumber__](https://github.com/nostur-com/nostur-ios-public)"
           }
         },
         "nl" : {
@@ -384,6 +522,12 @@
             "value" : "[#asknostr](nostur:t:asknostr)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#asknostr](buka:t:asknostr)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -395,6 +539,12 @@
     "[#beerstr](nostur:t:beerstr)" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#beerstr](nostur:t:beerstr)"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#beerstr](nostur:t:beerstr)"
@@ -416,6 +566,12 @@
             "value" : "[#bitcoin](nostur:t:bitcoin)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#bitcoin](lihat:t:bitcoin)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -432,6 +588,12 @@
             "value" : "[#cadenadecafe](nostur:t:cadenadecafe)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#rantai kopi](nostur:t:rantai kopi)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -443,6 +605,12 @@
     "[#foodstr](nostur:t:foodstr)" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#foodstr](nostur:t:foodstr)"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#foodstr](nostur:t:foodstr)"
@@ -464,6 +632,12 @@
             "value" : "[#footstr](nostur:t:footstr)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#footstr](nostur:t:footstr)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -478,6 +652,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#grownostr](nostur:t:grownostr)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#grownostr](lihat:t:grownostr)"
           }
         },
         "nl" : {
@@ -496,6 +676,12 @@
             "value" : "[#memes](nostur:t:memes)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#memes](nostur:t:meme)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -510,6 +696,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#música](nostur:t:música)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#musik](nostur:t:musik)"
           }
         },
         "nl" : {
@@ -528,6 +720,12 @@
             "value" : "[#nostr](nostur:t:nostr)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#nostr](lihat:t:nostr)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -539,6 +737,12 @@
     "[#winestr](nostur:t:winestr)" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#winestr](nostur:t:winestr)"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#winestr](nostur:t:winestr)"
@@ -558,6 +762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "[#zapathon](nostur:t:zapathon)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[#zapathon](lihat:t:zapathon)"
           }
         },
         "nl" : {
@@ -582,6 +792,12 @@
             "value" : "[%1$@](%2$@)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[%1$@](%2$@)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -599,6 +815,12 @@
             "value" : "[Zap](nostur:e:%@) falló.\n%@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[Zap](nostur:e:%@) gagal.\n%@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -610,6 +832,12 @@
     "@%@" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "@%@"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "@%@"
@@ -632,6 +860,12 @@
             "value" : "**%@** y %lld otros te están siguiendo ahora."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** dan %lld lainnya kini mengikuti Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -646,6 +880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**%@** y %lld otros reaccionaron a tu publicación."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** dan %lld lainnya bereaksi pada postingan Anda"
           }
         },
         "nl" : {
@@ -670,6 +910,12 @@
             "value" : "**%1$@** y %2$lld otros reaccionaron a tu mensaje privado."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%1$@** dan %2$lld lainnya bereaksi pada pesan pribadi Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -687,6 +933,12 @@
             "value" : "**%@** y %lld otros enviaron un zap a tu publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** dan %lld lainnya mengirim zap ke postingan Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -701,6 +953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**%@** por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** oleh"
           }
         },
         "nl" : {
@@ -720,6 +978,12 @@
             "value" : "**%@** ahora te está siguiendo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** sekarang mengikuti Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -736,6 +1000,12 @@
             "value" : "**%@** reaccionó a tu publicación."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** bereaksi pada postingan Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -750,6 +1020,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**%@** reaccionó a tu mensaje privado."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** bereaksi pada pesan pribadi Anda"
           }
         },
         "nl" : {
@@ -769,6 +1045,12 @@
             "value" : "**%@** envió un zap a tu publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** mengirim zap ke postingan Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -784,6 +1066,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**%@** envió un zap a tu perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** mengirim zap ke profil Anda"
           }
         },
         "nl" : {
@@ -803,6 +1091,12 @@
             "value" : "**%lld** Siguiendo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%lld** Berikut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -818,6 +1112,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**♾️** Seguidores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**♾️** Pengikut"
           }
         },
         "nl" : {
@@ -836,6 +1136,12 @@
             "value" : "**Error de inicio de sesión**"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Kesalahan masuk**"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -850,6 +1156,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Tiempo de espera de inicio de sesión**"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Batas waktu masuk**"
           }
         },
         "nl" : {
@@ -869,6 +1181,12 @@
             "value" : "**CLAVE PRIVADA:** %@∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**KUNCI PRIBADI:** %@∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗∗"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -884,6 +1202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**LLAVE PÚBLICA:** %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**KUNCI PUBLIK:** %@"
           }
         },
         "nl" : {
@@ -902,6 +1226,12 @@
             "value" : "**Enviar ahora**"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Kirim sekarang**"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -916,6 +1246,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Enviando publicación...**"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Mengirim postingan...**"
           }
         },
         "nl" : {
@@ -934,6 +1270,12 @@
             "value" : "**Error al firmar**"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Penandatanganan gagal**"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -948,6 +1290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**Publicación de firma...**"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Menandatangani postingan...**"
           }
         },
         "nl" : {
@@ -967,6 +1315,12 @@
             "value" : "**Términos y condiciones**"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Syarat dan Ketentuan**"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -981,6 +1335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "/ %@ máx."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/ %@ maks"
           }
         },
         "nl" : {
@@ -999,6 +1359,12 @@
             "value" : "%@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1010,6 +1376,12 @@
     "%@ " : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ "
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ "
@@ -1036,6 +1408,12 @@
             "state" : "translated",
             "value" : "%1$@ (%2$lld)"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$lld)"
+          }
         }
       },
       "shouldTranslate" : false
@@ -1046,6 +1424,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (Tiempo de espera u otro error)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (Waktu habis atau kesalahan lainnya)"
           }
         },
         "nl" : {
@@ -1065,6 +1449,12 @@
           }
         },
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@"
@@ -1092,6 +1482,12 @@
             "value" : "%1$@ %2$@ %3$@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ %3$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1106,6 +1502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ oleh"
           }
         },
         "nl" : {
@@ -1130,6 +1532,12 @@
             "value" : "%1$@ por %2$@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ oleh %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1144,6 +1552,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ Comprobando relays..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Memeriksa relays..."
           }
         },
         "nl" : {
@@ -1163,6 +1577,12 @@
             "value" : "%@ Siguiendo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Mengikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1177,6 +1597,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ no ha publicado relays preferido o está utilizando una configuración anterior."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ belum menerbitkan relays pilihan atau menggunakan konfigurasi lama."
           }
         },
         "nl" : {
@@ -1201,6 +1627,12 @@
             "value" : "kind %1$@ tipo %2$@ aún no compatible"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kind %1$@ tipe %2$@ belum didukung"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1215,6 +1647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ Sin conexión a Internet"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Tidak ada koneksi internet"
           }
         },
         "nl" : {
@@ -1233,6 +1671,12 @@
             "value" : "%@ lee publicaciones de"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ membaca postingan dari"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1249,6 +1693,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ volvió a publicar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ mem-posting ulang"
           }
         },
         "nl" : {
@@ -1273,6 +1723,12 @@
             "value" : "%1$@ sats %2$@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ dengan %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1287,6 +1743,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ Enviar sats"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Kirim sats"
           }
         },
         "nl" : {
@@ -1306,6 +1768,12 @@
             "value" : "Configuración de %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1321,6 +1789,12 @@
             "state" : "translated",
             "value" : "%@ sintonizado"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ disetel"
+          }
         }
       }
     },
@@ -1331,6 +1805,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feed de %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan %@"
           }
         },
         "nl" : {
@@ -1349,6 +1829,12 @@
             "value" : "Las publicaciones de %@ se pueden encontrar en"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan %@ dapat ditemukan di"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1363,6 +1849,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las reacciones de %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reaksi %@"
           }
         },
         "nl" : {
@@ -1381,12 +1873,24 @@
             "state" : "translated",
             "value" : "%lf"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lf"
+          }
         }
       }
     },
     "%lld" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -1406,6 +1910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contactos %lld seleccionados"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld kontak dipilih"
           }
         },
         "nl" : {
@@ -1454,6 +1964,24 @@
             }
           }
         },
+        "id" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Percakapan %lld disembunyikan oleh Anda"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Percakapan %lld disembunyikan oleh Anda"
+                }
+              }
+            }
+          }
+        },
         "nl" : {
           "variations" : {
             "plural" : {
@@ -1482,6 +2010,12 @@
             "value" : "emojis %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "emoji %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1497,6 +2031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld Siguiendo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Mengikuti"
           }
         },
         "nl" : {
@@ -1515,6 +2055,12 @@
             "value" : "Oyentes %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendengar %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1529,6 +2075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld lectura mínima"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld min dibaca"
           }
         },
         "nl" : {
@@ -1547,6 +2099,12 @@
             "value" : "%lld más"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld lebih lanjut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1561,6 +2119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Participantes de %lld"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "peserta %lld"
           }
         },
         "nl" : {
@@ -1579,6 +2143,12 @@
             "value" : "%lld relays deshabilitado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld relays dinonaktifkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1594,6 +2164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Solicitudes %lld no mostradas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permintaan %lld tidak ditampilkan"
           }
         },
         "nl" : {
@@ -1642,6 +2218,24 @@
             }
           }
         },
+        "id" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Permintaan %lld di luar Web of Trust"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Permintaan %lld di luar Web of Trust"
+                }
+              }
+            }
+          }
+        },
         "nl" : {
           "variations" : {
             "plural" : {
@@ -1670,6 +2264,12 @@
             "value" : "Espectadores %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pemirsa"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1686,12 +2286,24 @@
             "state" : "translated",
             "value" : "+"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+"
+          }
         }
       }
     },
     "+%lld" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+%lld"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "+%lld"
@@ -1713,6 +2325,12 @@
             "value" : "+%lld otros"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+%lld lainnya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1724,6 +2342,12 @@
     "+1" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+1"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "+1"
@@ -1746,6 +2370,12 @@
             "value" : "+15"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+15"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1758,6 +2388,12 @@
     "♾️" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "♾️"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "♾️"
@@ -1780,6 +2416,12 @@
             "value" : "⚠️"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1797,6 +2439,12 @@
             "state" : "translated",
             "value" : "⚠️Error: %@"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️ Kesalahan: %@"
+          }
         }
       }
     },
@@ -1807,6 +2455,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "⚡️⚡️ No se pudo enviar la solicitud NWC"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚡️⚡️ Tidak dapat mengirim permintaan NWC"
           }
         }
       }
@@ -1819,12 +2473,24 @@
             "state" : "translated",
             "value" : "✅ Descargado: %@"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "✅ Diunduh: %@"
+          }
         }
       }
     },
     "❤️" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "❤️"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "❤️"
@@ -1841,6 +2507,12 @@
             "value" : "📸"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "📸"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1852,6 +2524,12 @@
     "📽️" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "📽️"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "📽️"
@@ -1874,6 +2552,12 @@
             "value" : "🤫 Siguiendo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤫 Mengikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1885,6 +2569,12 @@
     "🥪" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🥪"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🥪"
@@ -1907,6 +2597,12 @@
             "value" : "🧨"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🧨"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1923,6 +2619,12 @@
             "state" : "translated",
             "value" : "🧩"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🧩"
+          }
         }
       }
     },
@@ -1933,12 +2635,24 @@
             "state" : "translated",
             "value" : "🫥"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🫥"
+          }
         }
       }
     },
     "😂" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "😂"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "😂"
@@ -1955,6 +2669,12 @@
     "😡" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "😡"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "😡"
@@ -1977,6 +2697,12 @@
             "value" : "0"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1988,6 +2714,12 @@
     "1" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1"
@@ -2009,6 +2741,12 @@
             "value" : "1) Envíe una captura de pantalla de este error y espere una actualización que solucione el problema."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1) Kirim tangkapan layar kesalahan ini dan tunggu pembaruan dengan perbaikan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2021,6 +2759,12 @@
       "comment" : "Short for 1 day (time frame)",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1d"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1d"
@@ -2043,6 +2787,12 @@
             "value" : "1 metro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1m"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2058,6 +2808,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1s"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1w"
           }
         },
         "nl" : {
@@ -2077,6 +2833,12 @@
             "value" : "1 año"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 tahun"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2091,6 +2853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2) Reinstale la aplicación y comience de nuevo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2) Instal ulang aplikasi dan mulai dari awal"
           }
         },
         "nl" : {
@@ -2109,6 +2877,12 @@
             "value" : "2h"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2123,6 +2897,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "4h"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 jam"
           }
         },
         "nl" : {
@@ -2141,6 +2921,12 @@
             "value" : "8h"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2155,6 +2941,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "12h"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 jam"
           }
         },
         "nl" : {
@@ -2173,6 +2965,12 @@
             "value" : "24h"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2189,6 +2987,12 @@
             "value" : "48h"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "48 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2200,6 +3004,12 @@
     "250" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "250"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "250"
@@ -2221,6 +3031,12 @@
             "value" : "500"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "500"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2232,6 +3048,12 @@
     "1000" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1000"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1000"
@@ -2253,6 +3075,12 @@
             "value" : "2000"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2000"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2267,6 +3095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Un cliente nostr para iOS y macOS - nostur.com"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klien nostr untuk iOS & macOS - nostur.com"
           }
         },
         "nl" : {
@@ -2286,6 +3120,12 @@
             "value" : "Aceptar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menerima"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2301,6 +3141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aceptar solicitud de mensaje"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terima permintaan pesan"
           }
         },
         "nl" : {
@@ -2320,6 +3166,12 @@
             "value" : "Aceptado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterima"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2335,6 +3187,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cuenta"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun"
           }
         },
         "nl" : {
@@ -2354,6 +3212,12 @@
             "value" : "La cuenta no tiene clave privada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun tidak memiliki kunci pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2368,6 +3232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menú de cuenta"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu akun"
           }
         },
         "nl" : {
@@ -2394,6 +3264,12 @@
             "value" : "Cuenta: @%1$@ / %2$@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun: @%1$@ / %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2411,6 +3287,12 @@
             "value" : "Cuentas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2425,6 +3307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cuentas encontradas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun ditemukan"
           }
         },
         "nl" : {
@@ -2444,6 +3332,12 @@
             "value" : "Activar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengaktifkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2458,6 +3352,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activar imagen en imagen"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan Gambar-dalam-Gambar"
           }
         },
         "nl" : {
@@ -2477,6 +3377,12 @@
             "value" : "Activa este filtro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan filter ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2491,6 +3397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktif"
           }
         },
         "nl" : {
@@ -2508,6 +3420,12 @@
             "state" : "translated",
             "value" : "Suscripciones activas (%lld)"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langganan aktif (%lld)"
+          }
         }
       }
     },
@@ -2517,6 +3435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menambahkan"
           }
         },
         "nl" : {
@@ -2536,6 +3460,12 @@
             "value" : "Añadir (%lld)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan (%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2553,6 +3483,12 @@
             "value" : "Agregar (firmante remoto)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan (penandatangan jarak jauh)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2567,6 +3503,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar (firmante remoto)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan (Penandatangan Jarak Jauh)"
           }
         },
         "nl" : {
@@ -2587,6 +3529,12 @@
             "value" : "Agregar contactos %lld al feed personalizado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak %lld ke umpan khusus"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2604,6 +3552,12 @@
             "value" : "Agregar contactos %lld a la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak %lld ke Daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2619,6 +3573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Añadir +7"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan +7"
           }
         },
         "nl" : {
@@ -2639,6 +3599,12 @@
             "value" : "Agregar un título"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan keterangan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2653,6 +3619,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar todo a la lista personalizada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan semua ke daftar khusus"
           }
         },
         "nl" : {
@@ -2672,6 +3644,12 @@
             "value" : "Agregar de nuevo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kembali"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2687,6 +3665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar servidor de flores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan server mekar"
           }
         },
         "nl" : {
@@ -2705,6 +3689,12 @@
             "value" : "Agregar servidor Blossom"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan server Blossom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2719,6 +3709,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar columna"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kolom"
           }
         },
         "nl" : {
@@ -2738,6 +3734,12 @@
             "value" : "Añadir comentario"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan komentar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2752,6 +3754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Añadir contacto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak"
           }
         },
         "nl" : {
@@ -2770,6 +3778,12 @@
             "value" : "Añadir contacto..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2785,6 +3799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar contactos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak"
           }
         },
         "nl" : {
@@ -2805,6 +3825,12 @@
             "value" : "Agregar contactos al feed"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kontak ke umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2820,6 +3846,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar cuenta existente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan akun yang ada"
           }
         },
         "nl" : {
@@ -2839,6 +3871,12 @@
             "value" : "Agregar servidor de medios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan server media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2855,6 +3893,12 @@
             "state" : "translated",
             "value" : "Agregar palabra silenciada"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan kata yang dibisukan"
+          }
         }
       }
     },
@@ -2864,6 +3908,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Añadir nuevo relay..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan relay baru..."
           }
         },
         "nl" : {
@@ -2884,6 +3934,12 @@
             "value" : "Agregar nota privada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan catatan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2899,6 +3955,12 @@
             "state" : "translated",
             "value" : "Agregar nota privada (opcional)"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan catatan pribadi (opsional)"
+          }
         }
       }
     },
@@ -2909,6 +3971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar nota privada a la publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan catatan pribadi ke postingan"
           }
         },
         "nl" : {
@@ -2925,6 +3993,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar nota pública (opcional)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan catatan publik (opsional)"
           }
         },
         "nl" : {
@@ -2944,6 +4018,12 @@
             "value" : "Añadir relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2958,6 +4038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Añade este feed a tus pestañas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan umpan ini ke tab Anda"
           }
         },
         "nl" : {
@@ -2976,6 +4062,12 @@
             "value" : "Agregar a la lista existente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan ke daftar yang ada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2992,6 +4084,12 @@
             "value" : "Agregar a nueva lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan ke daftar baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3006,6 +4104,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Añadir al escenario"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan ke panggung"
           }
         },
         "nl" : {
@@ -3026,6 +4130,12 @@
             "value" : "Agregar/eliminar %@ del feed personalizado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan/Hapus %@ dari umpan khusus"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3042,6 +4152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar o quitar del feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambah/Hapus dari umpan"
           }
         },
         "nl" : {
@@ -3062,6 +4178,12 @@
             "value" : "Agregar/eliminar de feeds"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambah/Hapus dari feed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3077,6 +4199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar/eliminar de Destacados"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambah/hapus dari Sorotan"
           }
         },
         "nl" : {
@@ -3096,6 +4224,12 @@
             "value" : "Agregar/eliminar de listas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambah/hapus dari Daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3111,6 +4245,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agregar/eliminar de listas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambah/Hapus dari Daftar"
           }
         },
         "nl" : {
@@ -3130,6 +4270,12 @@
             "value" : "Todo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3145,6 +4291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Todas las cuentas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua akun"
           }
         },
         "nl" : {
@@ -3163,6 +4315,12 @@
             "value" : "Todos los participantes deben tener publicado su DM relays para iniciar un chat grupal."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semua peserta harus mempublikasikan DM relays mereka untuk memulai obrolan grup."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3177,6 +4335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cantidad (satoshis)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah (satoshi)"
           }
         },
         "nl" : {
@@ -3196,6 +4360,12 @@
             "value" : "y %lld más"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dan %lld lainnya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3210,6 +4380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "y %lld otros que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dan %lld lainnya yang Anda ikuti"
           }
         },
         "nl" : {
@@ -3228,6 +4404,12 @@
             "value" : "y 1 persona más a la que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dan 1 orang lainnya yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3242,6 +4424,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anuncie su relays..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umumkan relays Anda..."
           }
         },
         "nl" : {
@@ -3260,6 +4448,12 @@
             "value" : "Anunciado relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diumumkan relays"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3276,6 +4470,12 @@
             "value" : "Anunciado relays para %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengumumkan relays untuk %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3290,6 +4490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tema de la aplicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema aplikasi"
           }
         },
         "nl" : {
@@ -3309,6 +4515,12 @@
             "value" : "Apariencia"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penampilan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3325,6 +4537,12 @@
             "value" : "Aprobar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyetujui"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3339,6 +4557,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¿Aprobar el inicio de sesión en %@?"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setujui login di %@?"
           }
         },
         "nl" : {
@@ -3358,6 +4582,12 @@
             "value" : "¿Estás seguro de que quieres eliminar tu cuenta?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apakah Anda yakin ingin menghapus akun Anda?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3374,6 +4604,12 @@
             "value" : "Configuración del feed de artículos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan umpan artikel"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3388,6 +4624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Periodo de tiempo de alimentación del artículo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu pengumpanan artikel"
           }
         },
         "nl" : {
@@ -3407,6 +4649,12 @@
             "value" : "Artículos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artikel"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3422,6 +4670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "autenticación requerida"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "diperlukan autentikasi"
           }
         },
         "nl" : {
@@ -3440,6 +4694,12 @@
             "value" : "Autenticar como"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otentikasi sebagai"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3454,6 +4714,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autenticar con"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otentikasi dengan"
           }
         },
         "nl" : {
@@ -3472,6 +4738,12 @@
             "value" : "Autenticando con cuenta: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengautentikasi dengan akun: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3487,6 +4759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desplazamiento automático a nuevas publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gulir otomatis ke postingan baru"
           }
         },
         "nl" : {
@@ -3512,6 +4790,12 @@
             "value" : "Irrestricto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dibatasi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3533,6 +4817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sólo Web of Trust"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web of Trust saja"
           }
         },
         "nl" : {
@@ -3558,6 +4848,12 @@
             "value" : "Sólo siguiendo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya mengikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3573,6 +4869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conéctate automáticamente a relays adicionales de las personas que sigues para reducir el contenido faltante que no se puede encontrar en tu propio conjunto relay."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terhubung secara otomatis ke relays tambahan dari orang yang Anda ikuti untuk mengurangi konten hilang yang tidak dapat ditemukan di kumpulan relay Anda sendiri"
           }
         },
         "nl" : {
@@ -3592,6 +4894,12 @@
             "value" : "Piloto automático"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilot otomatis"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3606,6 +4914,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El piloto automático transmitirá a los siguientes relays adicionales"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autopilot akan disiarkan ke relays tambahan berikut"
           }
         },
         "nl" : {
@@ -3625,6 +4939,12 @@
             "value" : "Premio a"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penghargaan kepada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3640,6 +4960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Premio a la gente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penghargaan kepada orang-orang"
           }
         },
         "nl" : {
@@ -3659,6 +4985,12 @@
             "value" : "Otorgado a personas %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diberikan kepada orang-orang %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3674,6 +5006,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Otorgado a personas %lld en %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diberikan kepada orang-orang %lld di %@"
           }
         },
         "nl" : {
@@ -3693,6 +5031,12 @@
             "value" : "Atrás"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kembali"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3710,6 +5054,12 @@
             "value" : "Insignias"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lencana"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3724,6 +5074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insignias recibidas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lencana diterima"
           }
         },
         "nl" : {
@@ -3743,6 +5099,12 @@
             "value" : "Insignias: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lencana: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3757,6 +5119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Según su selección, se publicará el siguiente conjunto relay para que otros puedan acceder a la cuenta: %@."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berdasarkan pilihan Anda, kumpulan relay berikut akan dipublikasikan sehingga orang lain dapat menghubungi akun: %@."
           }
         },
         "nl" : {
@@ -3776,6 +5144,12 @@
             "value" : "Biografía"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biografi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3791,6 +5165,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Factura Bitcoin Lightning ⚡️"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faktur Bitcoin Lightning ⚡️"
           }
         },
         "nl" : {
@@ -3809,6 +5189,12 @@
             "value" : "Blanco y negro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hitam & Putih"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3823,6 +5209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquear"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memblokir"
           }
         },
         "nl" : {
@@ -3842,6 +5234,12 @@
             "value" : "Bloque %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3856,6 +5254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquear por 1 día"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 1 hari"
           }
         },
         "nl" : {
@@ -3874,6 +5278,12 @@
             "value" : "Bloquear durante 1 hora"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 1 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3888,6 +5298,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquear por 1 mes"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 1 bulan"
           }
         },
         "nl" : {
@@ -3906,6 +5322,12 @@
             "value" : "Bloquear por 1 semana"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 1 minggu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3922,6 +5344,12 @@
             "value" : "Bloquear durante 4 horas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 4 jam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3936,6 +5364,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquear durante 8 horas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blokir selama 8 jam"
           }
         },
         "nl" : {
@@ -3955,6 +5389,12 @@
             "value" : "Lista de bloqueo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar blokir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3972,6 +5412,12 @@
             "value" : "Bloqueados"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diblokir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3986,6 +5432,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "bloqueado hasta %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "diblokir sampai %@"
           }
         },
         "nl" : {
@@ -4005,6 +5457,12 @@
             "value" : "servidor Blossom"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Blossom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4019,6 +5477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Servidores Blossom"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Blossom"
           }
         },
         "nl" : {
@@ -4037,6 +5501,12 @@
             "value" : "Azul"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4053,6 +5523,12 @@
             "value" : "Marcador"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penanda buku"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4067,6 +5543,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "marcadores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "penanda buku"
           }
         },
         "nl" : {
@@ -4086,6 +5568,12 @@
             "value" : "Marcadores"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bookmark"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4101,6 +5589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Marcadores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penanda buku"
           }
         },
         "nl" : {
@@ -4120,6 +5614,12 @@
             "value" : "Transmitir evento nostr"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siarkan acara nostr"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4135,6 +5635,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurador de botones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengonfigurasi tombol"
           }
         },
         "nl" : {
@@ -4153,6 +5659,12 @@
             "value" : "por"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "oleh"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4167,6 +5679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Al continuar aceptas las"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dengan melanjutkan, Anda menyetujui"
           }
         },
         "nl" : {
@@ -4187,6 +5705,12 @@
             "value" : "cachés"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tembolok"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4202,6 +5726,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Calculador..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghitung..."
           }
         },
         "nl" : {
@@ -4220,6 +5750,12 @@
             "state" : "translated",
             "value" : "Se necesita acceso a la cámara para escanear un código QR de NWC"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akses kamera diperlukan untuk memindai kode QR NWC"
+          }
         }
       }
     },
@@ -4229,6 +5765,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membatalkan"
           }
         },
         "nl" : {
@@ -4248,6 +5790,12 @@
             "value" : "Cancelado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dibatalkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4264,6 +5812,12 @@
             "value" : "No puedo encontrar una cuenta para autenticarme"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menemukan akun untuk diautentikasi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4276,6 +5830,12 @@
       "comment" : "Title of cashu redeem card",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cashu (Bitcoin) 🥜"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cashu (Bitcoin) 🥜"
@@ -4297,6 +5857,12 @@
             "value" : "Cambiar cuenta"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ganti akun"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4313,6 +5879,12 @@
             "state" : "translated",
             "value" : "Comprobado"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diperiksa"
+          }
         }
       }
     },
@@ -4322,6 +5894,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comprobando relays para su lista de servidores Blossom..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memeriksa relays untuk daftar server blossom Anda..."
           }
         },
         "nl" : {
@@ -4340,6 +5918,12 @@
             "value" : "Comprobando qué les pareció gracioso a tus seguidores..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memeriksa apa yang menurut pengikut Anda lucu..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4354,6 +5938,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comprobando a qué volvieron a publicar o reaccionaron tus seguidores..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memeriksa apa yang diposkan ulang atau ditanggapi oleh pengikut Anda..."
           }
         },
         "nl" : {
@@ -4371,6 +5961,12 @@
             "state" : "translated",
             "value" : "Comprobando lo que tus seguidores compartieron..."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memeriksa apa yang dibagikan pengikut Anda..."
+          }
         }
       }
     },
@@ -4380,6 +5976,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comprobando lo que sigues zapped..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memeriksa apa yang Anda ikuti zapped..."
           }
         },
         "nl" : {
@@ -4398,6 +6000,12 @@
             "value" : "Elige una foto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih foto"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4412,6 +6020,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elija un relay popular para que la gente pueda encontrar fácilmente sus publicaciones y elija un relay alternativo, preferiblemente el suyo, donde la gente siempre pueda encontrar sus publicaciones en caso de que el popular relay tenga problemas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih relay yang populer sehingga orang dapat dengan mudah menemukan postingan Anda dan pilih relay alternatif, sebaiknya milik Anda sendiri, di mana orang selalu dapat menemukan postingan Anda jika relay yang populer mengalami masalah."
           }
         },
         "nl" : {
@@ -4430,6 +6044,12 @@
             "value" : "Elija un relay que requiera autenticación para recibir mensajes privados."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih relay yang memerlukan autentikasi untuk menerima pesan pribadi."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4444,6 +6064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elige cuenta"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih akun"
           }
         },
         "nl" : {
@@ -4463,6 +6089,12 @@
             "value" : "Elija contenido para esta columna"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih konten untuk kolom ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4478,6 +6110,12 @@
             "state" : "translated",
             "value" : "Elige emoji personalizado:"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih emoji khusus:"
+          }
         }
       }
     },
@@ -4487,6 +6125,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elija la lista existente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih daftar yang ada"
           }
         },
         "nl" : {
@@ -4506,6 +6150,12 @@
             "value" : "Elige feed"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4521,6 +6171,12 @@
             "state" : "translated",
             "value" : "Elige de la biblioteca"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih dari perpustakaan"
+          }
         }
       }
     },
@@ -4530,6 +6186,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elija uno o más relays públicos desde los que lea para poder recibir notificaciones cuando otros lo mencionen."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih satu atau lebih relays publik yang Anda baca sehingga Anda dapat menerima pemberitahuan ketika orang lain menyebut Anda."
           }
         },
         "nl" : {
@@ -4548,6 +6210,12 @@
             "value" : "Elija relays para mensajes privados"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih relays untuk pesan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4564,6 +6232,12 @@
             "value" : "Elige etiquetar:"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih untuk menandai:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4578,6 +6252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Clásico"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasik"
           }
         },
         "nl" : {
@@ -4597,6 +6277,12 @@
             "value" : "Claro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jernih"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4612,6 +6298,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Borrar caché"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus cache"
           }
         },
         "nl" : {
@@ -4631,6 +6323,12 @@
             "value" : "Claro..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membersihkan..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4647,6 +6345,12 @@
             "state" : "translated",
             "value" : "El portapapeles no contiene un URI de Wallet Connect Nostr"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papan klip tidak berisi URI Nostr Wallet Connect"
+          }
         }
       }
     },
@@ -4658,6 +6362,12 @@
             "state" : "translated",
             "value" : "El portapapeles no contiene un URI válido de Nostr Wallet Connect"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papan klip tidak berisi URI Nostr Wallet Connect yang valid"
+          }
         }
       }
     },
@@ -4668,6 +6378,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cerrar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutup"
           }
         },
         "nl" : {
@@ -4686,6 +6402,12 @@
             "value" : "Cerrar todas las pestañas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutup semua tab"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4702,6 +6424,12 @@
             "value" : "Cerrar todas las pestañas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutup Semua Tab"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4716,6 +6444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cerrar habitación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutup ruangan"
           }
         },
         "nl" : {
@@ -4735,6 +6469,12 @@
             "value" : "Código (valentía, verificado_humano, early_adoptor)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kode (keberanian, manusia_terverifikasi, pengadopsi_awal)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4749,6 +6489,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Colapsar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runtuh"
           }
         },
         "nl" : {
@@ -4766,6 +6512,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Color Azul"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warna Biru"
           }
         },
         "nl" : {
@@ -4786,6 +6538,12 @@
             "value" : "Comentando en %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengomentari %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4800,6 +6558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comentando en el sitio web"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengomentari di situs web"
           }
         },
         "nl" : {
@@ -4818,6 +6582,12 @@
             "value" : "Comentarios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komentar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4832,6 +6602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comentarios en%@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komentar di %@"
           }
         },
         "nl" : {
@@ -4851,6 +6627,12 @@
             "value" : "Comunidades"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komunitas"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4866,6 +6648,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan"
           }
         },
         "nl" : {
@@ -4884,6 +6672,12 @@
             "value" : "Configurar anunciado relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan relays yang diumumkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4900,6 +6694,12 @@
             "value" : "Configurar servidores de Blossom"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan server mekar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4914,6 +6714,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurar columna"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan kolom"
           }
         },
         "nl" : {
@@ -4933,6 +6739,12 @@
             "value" : "Configurar contactos..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan kontak..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4948,6 +6760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurar feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan umpan"
           }
         },
         "nl" : {
@@ -4967,6 +6785,12 @@
             "value" : "Configurar el tipo de alimentación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan jenis umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4982,6 +6806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurar relays publicado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan relays yang diterbitkan"
           }
         },
         "nl" : {
@@ -5001,6 +6831,12 @@
             "value" : "Configurar relays..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan relays..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5016,6 +6852,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configura los botones de reacción para cada publicación. También puedes cambiar la posición o eliminar botones que no necesites."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan tombol reaksi untuk setiap posting. Anda juga dapat mengubah posisi atau menghapus tombol yang tidak diperlukan."
           }
         },
         "nl" : {
@@ -5034,6 +6876,12 @@
             "value" : "Configura tu DM relays..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan DM Anda relays..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5048,6 +6896,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configura tu relays..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan relays Anda..."
           }
         },
         "nl" : {
@@ -5067,6 +6921,12 @@
             "value" : "Confirmar cierre de sesión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfirmasikan logout"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5084,6 +6944,12 @@
             "value" : "Conectar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghubungkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5099,6 +6965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conecta la billetera Alby"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan dompet Alby"
           }
         },
         "nl" : {
@@ -5119,6 +6991,12 @@
             "value" : "Conéctese a relays adicionales de personas que sigue para reducir el contenido faltante que no se puede encontrar en su propio conjunto relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan ke relays tambahan dari orang yang Anda ikuti untuk mengurangi konten hilang yang tidak dapat ditemukan di kumpulan relay Anda sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5134,6 +7012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conéctese a relays incluido en los enlaces nostr cuando no se pueda encontrar el contenido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan ke relays yang disertakan dalam tautan nostr ketika konten tidak dapat ditemukan"
           }
         },
         "nl" : {
@@ -5153,6 +7037,12 @@
             "value" : "Conectar billetera"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan dompet"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5169,6 +7059,12 @@
             "value" : "Conecta tu billetera **Alby** con **Nostur** para una experiencia de zapping fluida"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan dompet **Alby** Anda dengan **Nostur** untuk pengalaman zapping yang lancar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5183,6 +7079,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conecta tu billetera compatible con NWC con **Nostur** para una experiencia de zapping fluida"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hubungkan dompet kompatibel NWC Anda dengan **Nostur** untuk pengalaman zapping yang lancar"
           }
         },
         "nl" : {
@@ -5202,6 +7104,12 @@
             "value" : "Conectado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terhubung"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5218,6 +7126,12 @@
             "state" : "translated",
             "value" : "conectando"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menghubungkan"
+          }
         }
       }
     },
@@ -5228,6 +7142,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectando..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghubungkan..."
           }
         },
         "nl" : {
@@ -5244,6 +7164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conexión"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi"
           }
         },
         "nl" : {
@@ -5263,6 +7189,12 @@
             "value" : "La conexión falló"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi gagal"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5278,6 +7210,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se agotó el tiempo de conexión"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu koneksi habis"
           }
         },
         "nl" : {
@@ -5297,6 +7235,12 @@
             "value" : "contacto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5311,6 +7255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contactos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontak"
           }
         },
         "nl" : {
@@ -5329,6 +7279,12 @@
             "value" : "Contactos de esta publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontak dari posting ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5345,6 +7301,12 @@
             "value" : "Contactos en la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontak dalam daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5359,6 +7321,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contactos:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontak:"
           }
         },
         "nl" : {
@@ -5378,6 +7346,12 @@
             "value" : "Contenido bloqueado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten diblokir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5393,6 +7367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contenido bloqueado (sin HTTPS)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten diblokir (Tanpa HTTPS)"
           }
         },
         "nl" : {
@@ -5412,6 +7392,12 @@
             "value" : "Contenido bloqueado (NSFW)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten diblokir (NSFW)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5426,6 +7412,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El contenido de estas cuentas que sigues se recibió de este relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten dari akun yang Anda ikuti diterima dari relay ini"
           }
         },
         "nl" : {
@@ -5445,6 +7437,12 @@
             "value" : "El contenido de estas cuentas que sigues se recibió este relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten dari akun yang Anda ikuti diterima relay ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5460,6 +7458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipos de contenido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipe konten"
           }
         },
         "nl" : {
@@ -5478,6 +7482,12 @@
             "value" : "Continuar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melanjutkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5493,6 +7503,12 @@
             "state" : "translated",
             "value" : "Continuar de forma anónima"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lanjutkan secara anonim"
+          }
         }
       }
     },
@@ -5503,6 +7519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conversación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percakapan"
           }
         },
         "nl" : {
@@ -5521,6 +7543,12 @@
             "state" : "translated",
             "value" : "Columna de conversación"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolom percakapan"
+          }
         }
       }
     },
@@ -5530,6 +7558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Detalles de la conversación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detail percakapan"
           }
         },
         "nl" : {
@@ -5549,6 +7583,12 @@
             "value" : "Información de conversación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informasi percakapan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5563,6 +7603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conversaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percakapan"
           }
         },
         "nl" : {
@@ -5581,6 +7627,12 @@
             "value" : "Copiar URL de imagen"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin URL gambar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5595,6 +7647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar dirección de lista"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin alamat daftar"
           }
         },
         "nl" : {
@@ -5612,6 +7670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar npub"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin npub"
           }
         },
         "nl" : {
@@ -5632,6 +7696,12 @@
             "value" : "Copiar texto de la publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin teks posting"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5647,6 +7717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar clave privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin kunci pribadi"
           }
         },
         "nl" : {
@@ -5666,6 +7742,12 @@
             "value" : "Copie la clave privada (nsec) al portapapeles"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin kunci pribadi (nsec) ke clipboard"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5681,6 +7763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar fuente del perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin sumber profil"
           }
         },
         "nl" : {
@@ -5701,6 +7789,12 @@
             "value" : "Copiar clave pública hexadecimal"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin hex kunci publik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5715,6 +7809,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar JSON sin formato"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin JSON mentah"
           }
         },
         "nl" : {
@@ -5733,6 +7833,12 @@
             "value" : "Copiar texto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin teks"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5749,6 +7855,12 @@
             "value" : "Copiar al portapapeles"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin ke papan klip"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5763,6 +7875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copiar URL del vídeo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salin URL video"
           }
         },
         "nl" : {
@@ -5782,6 +7900,12 @@
             "value" : "No se pudieron convertir los datos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengonversi data"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5798,6 +7922,12 @@
             "state" : "translated",
             "value" : "No se pudo crear la solicitud zap privada"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat membuat permintaan zap pribadi"
+          }
         }
       }
     },
@@ -5808,6 +7938,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pudo recuperar la factura"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil faktur"
           }
         },
         "nl" : {
@@ -5827,6 +7963,12 @@
             "value" : "No se pudo recuperar el evento de información NWC de %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil info acara NWC dari %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5843,6 +7985,12 @@
             "value" : "No se pudo encontrar DM relays para:"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menemukan DM relays untuk:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5857,6 +8005,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pudo encontrar el perfil de usuario más reciente (tipo 0)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menemukan profil pengguna terbaru (jenis-0)"
           }
         },
         "nl" : {
@@ -5876,6 +8030,12 @@
             "value" : "No se pudo analizar JSON"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menguraikan JSON"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5891,6 +8051,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pudo analizar el secreto del URI de conexión NWC"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menguraikan rahasia dari URI koneksi NWC"
           }
         },
         "nl" : {
@@ -5911,6 +8077,12 @@
             "value" : "No se pudo enviar la solicitud NWC"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengirim permintaan NWC"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5926,6 +8098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pudo firmar el evento"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menandatangani acara"
           }
         },
         "nl" : {
@@ -5945,6 +8123,12 @@
             "value" : "Contadores de respuestas, me gusta, zaps, etc."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penghitung untuk balasan, suka, zaps dll."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5961,6 +8145,12 @@
             "value" : "Crear"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membuat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5975,6 +8165,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea un vídeo corto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat video pendek"
           }
         },
         "nl" : {
@@ -5994,6 +8190,12 @@
             "value" : "Crear nueva cuenta"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat akun baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6009,6 +8211,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crear nueva insignia"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat lencana baru"
           }
         },
         "nl" : {
@@ -6029,6 +8237,12 @@
             "value" : "Crear nueva fuente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat umpan baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6043,6 +8257,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crear claves de prueba"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat kunci tes"
           }
         },
         "nl" : {
@@ -6061,6 +8281,12 @@
             "value" : "Crea tu Nido de Audio"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buat Sarang Audio Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6075,6 +8301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Crea una lista pública en nostr relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membuat daftar publik di nostr relays"
           }
         },
         "nl" : {
@@ -6093,6 +8325,12 @@
             "value" : "Actualmente permitido por el filtro: contactos %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saat ini diizinkan oleh filter: kontak %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6109,6 +8347,12 @@
             "value" : "Actualmente permitido por el filtro: Todos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saat ini diizinkan oleh filter: Semua Orang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6123,6 +8367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Costumbre"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kebiasaan"
           }
         },
         "nl" : {
@@ -6142,6 +8392,12 @@
             "value" : "Feed personalizado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Khusus"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6156,6 +8412,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feeds personalizados"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Khusus"
           }
         },
         "nl" : {
@@ -6175,6 +8437,12 @@
             "value" : "Almacenamiento de archivos personalizado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penyimpanan File Khusus"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6190,6 +8458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "relay personalizado para firmante"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relay khusus untuk penandatangan"
           }
         },
         "nl" : {
@@ -6210,6 +8484,12 @@
             "value" : "d"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "D"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6226,6 +8506,12 @@
             "value" : "granate oscuro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garnet Gelap"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6240,6 +8526,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Exportación de datos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekspor data"
           }
         },
         "nl" : {
@@ -6260,6 +8552,12 @@
             "value" : "Uso de datos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penggunaan data"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6277,6 +8575,12 @@
             "value" : "Uso de datos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penggunaan Data"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6291,6 +8595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Base de datos y caché"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basis Data & Tembolok"
           }
         },
         "nl" : {
@@ -6310,6 +8620,12 @@
             "value" : "Estado de la base de datos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status basis data"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6324,6 +8640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Día"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hari"
           }
         },
         "nl" : {
@@ -6342,6 +8664,12 @@
             "state" : "translated",
             "value" : "dddd"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hh"
+          }
         }
       }
     },
@@ -6351,6 +8679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "reconocimiento de decodificación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "memecahkan kode ack"
           }
         },
         "nl" : {
@@ -6369,6 +8703,12 @@
             "value" : "prueba de decodificación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tes dekode"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6383,6 +8723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "prueba de decodificación 2"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tes dekode 2"
           }
         },
         "nl" : {
@@ -6401,6 +8747,12 @@
             "value" : "prueba de decodificación 3"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tes dekode 3"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6415,6 +8767,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Descifrando..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mendekripsi..."
           }
         },
         "nl" : {
@@ -6433,6 +8791,12 @@
             "value" : "por defecto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bawaan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6447,6 +8811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Por defecto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bawaan"
           }
         },
         "nl" : {
@@ -6465,6 +8835,12 @@
             "value" : "Feeds predeterminados"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan bawaan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6481,6 +8857,12 @@
             "value" : "Cantidad predeterminada de zap"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah zap default"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6495,6 +8877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cantidad predeterminada de zap:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah zap bawaan:"
           }
         },
         "nl" : {
@@ -6514,6 +8902,12 @@
             "value" : "Borrar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghapus"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6529,6 +8923,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eliminar cuenta"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus akun"
           }
         },
         "nl" : {
@@ -6548,6 +8948,12 @@
             "value" : "Eliminar feed %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus umpan %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6563,6 +8969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eliminar nota privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus catatan pribadi"
           }
         },
         "nl" : {
@@ -6582,6 +8994,12 @@
             "value" : "Eliminando en %lld segundos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghapus dalam %lld detik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6596,6 +9014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Entrega a relays de"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengiriman ke relays dari"
           }
         },
         "nl" : {
@@ -6614,6 +9038,12 @@
             "value" : "Entrega a tu DM relays (respaldo):"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengiriman ke DM relays Anda (cadangan):"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6628,6 +9058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "describir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menggambarkan"
           }
         },
         "nl" : {
@@ -6647,6 +9083,12 @@
             "value" : "Descripción"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keterangan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6661,6 +9103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuración de mensajes directos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan Pesan Langsung"
           }
         },
         "nl" : {
@@ -6680,6 +9128,12 @@
             "value" : "Los mensajes directos que utilizan un inicio de sesión de nsecBunker aún no están disponibles"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direct Message yang menggunakan login nsecBunker belum tersedia"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6694,6 +9148,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Los mensajes directos que utilizan un firmante remoto aún no están disponibles"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direct Message yang menggunakan penanda tangan jarak jauh belum tersedia"
           }
         },
         "nl" : {
@@ -6713,6 +9173,12 @@
             "value" : "Desactivar para mejorar el rendimiento del desplazamiento"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nonaktifkan untuk meningkatkan kinerja pengguliran"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6729,6 +9195,12 @@
             "value" : "Desactivado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dengan disabilitas"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6743,6 +9215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deshabilitado relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays dinonaktifkan"
           }
         },
         "nl" : {
@@ -6762,6 +9240,12 @@
             "value" : "Desconectar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memutuskan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6777,6 +9261,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desconectado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terputus"
           }
         },
         "nl" : {
@@ -6796,6 +9286,12 @@
             "value" : "Descubrir"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menemukan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6813,6 +9309,12 @@
             "value" : "Descubra comunidades"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan Komunitas"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6827,6 +9329,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Descubra el período de tiempo de alimentación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan kerangka waktu umpan"
           }
         },
         "nl" : {
@@ -6847,6 +9355,12 @@
             "value" : "Descubrir listas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan Daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6861,6 +9375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Descubre Nostr"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan Nostr"
           }
         },
         "nl" : {
@@ -6881,6 +9401,12 @@
             "value" : "Mostrar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menampilkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6897,6 +9423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "divinidades"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dewa"
           }
         },
         "nl" : {
@@ -6916,6 +9448,12 @@
             "value" : "Divinos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dewa"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6929,6 +9467,12 @@
       "extractionState" : "stale",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DM"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DM"
@@ -6950,6 +9494,12 @@
             "value" : "DM relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DM relays"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6966,6 +9516,12 @@
             "value" : "dm: recibes mensajes privados de este relay, por lo que otros deberían enviar mensajes privados allí."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dm: Anda menerima pesan pribadi dari relay ini, jadi orang lain harus mengirim pesan pribadi ke sana."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6977,6 +9533,12 @@
     "DMs" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DM"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DM"
@@ -6998,6 +9560,12 @@
             "value" : "Hecho"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selesai"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7012,6 +9580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Descargar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unduh"
           }
         },
         "nl" : {
@@ -7030,6 +9604,12 @@
             "value" : "Descargando..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengunduh..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7044,6 +9624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arrastre los controles para recortar el video"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seret pengendali untuk memangkas video"
           }
         },
         "nl" : {
@@ -7062,6 +9648,12 @@
             "value" : "Soltar imagen..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jatuhkan gambar..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7076,6 +9668,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "número de dunbar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nomor Dunbar"
           }
         },
         "nl" : {
@@ -7095,6 +9693,12 @@
             "value" : "Duración"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lamanya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7111,6 +9715,12 @@
             "state" : "translated",
             "value" : "carga temprana"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "beban awal"
+          }
         }
       }
     },
@@ -7121,6 +9731,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editar palabra silenciada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit kata yang dibisukan"
           }
         },
         "nl" : {
@@ -7140,6 +9756,12 @@
             "value" : "Editar nota privada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit catatan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7155,6 +9777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editar perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunting profil"
           }
         },
         "nl" : {
@@ -7174,6 +9802,12 @@
             "value" : "Editar relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunting relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7189,6 +9823,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editar feed relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit umpan relays"
           }
         },
         "nl" : {
@@ -7208,6 +9848,12 @@
             "value" : "Editar título"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunting judul"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7225,6 +9871,12 @@
             "value" : "Feed de emojis"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Emoji"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7239,6 +9891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Periodo de tiempo de alimentación de emojis"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu umpan emoji"
           }
         },
         "nl" : {
@@ -7258,6 +9916,12 @@
             "value" : "Habilitar fotos de perfil animadas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan foto profil animasi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7273,6 +9937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Habilitar autenticación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan otentikasi"
           }
         },
         "nl" : {
@@ -7292,6 +9962,12 @@
             "value" : "Habilitar imágenes de ancho completo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan gambar lebar penuh"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7307,6 +9983,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Habilitar filtro Web of Trust"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan filter Web of Trust"
           }
         },
         "nl" : {
@@ -7325,6 +10007,12 @@
             "value" : "Habilitar filtro WoT"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan filter WoT"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7339,6 +10027,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imagen cifrada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar Terenkripsi"
           }
         },
         "nl" : {
@@ -7357,6 +10051,12 @@
             "value" : "Cifrando y cargando..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengenkripsi dan mengunggah..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7372,6 +10072,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Finalizar prueba"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes akhir"
           }
         },
         "nl" : {
@@ -7393,6 +10099,12 @@
             "value" : "Enrutamiento Relay mejorado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perutean Relay yang Ditingkatkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7407,6 +10119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingrese una dirección de servidor de medios compatible con NIP-96 para alojar sus imágenes"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan alamat server media yang kompatibel dengan NIP-96 untuk menghosting gambar Anda"
           }
         },
         "nl" : {
@@ -7426,6 +10144,12 @@
             "value" : "Introduzca JSON"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan JSON"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7442,6 +10166,12 @@
             "value" : "Introduzca el nombre de la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan nama daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7456,6 +10186,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingrese la nueva dirección relay..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan alamat relay baru..."
           }
         },
         "nl" : {
@@ -7475,6 +10211,12 @@
             "value" : "Ingrese la dirección nsecBunker relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan alamat nsecBunker relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7490,6 +10232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingrese una nota privada sobre %@ para usted"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan catatan pribadi tentang %@ untuk Anda sendiri"
           }
         },
         "nl" : {
@@ -7509,6 +10257,12 @@
             "value" : "Ingrese una nota privada sobre esta publicación para usted"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan catatan pribadi tentang posting ini untuk Anda sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7524,6 +10278,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingrese una nota privada sobre este usuario para usted"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan catatan pribadi tentang pengguna ini untuk Anda sendiri"
           }
         },
         "nl" : {
@@ -7543,6 +10303,12 @@
             "value" : "Ingrese una nota privada para usted"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan catatan pribadi untuk Anda sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7557,6 +10323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Introduzca la dirección relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan alamat relay"
           }
         },
         "nl" : {
@@ -7576,6 +10348,12 @@
             "value" : "Introduce tu nombre"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan nama Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7590,6 +10368,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan"
           }
         },
         "nl" : {
@@ -7610,6 +10394,12 @@
             "value" : "Mensajes de error para %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan kesalahan untuk %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7624,6 +10414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error: 00"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan: 00"
           }
         },
         "nl" : {
@@ -7644,6 +10440,12 @@
             "value" : "Error: no se pudo encontrar la clave pública del contacto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan: tidak dapat menemukan kunci pub kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7658,6 +10460,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error: falta archivo de audio"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan: file audio hilang"
           }
         },
         "nl" : {
@@ -7676,6 +10484,12 @@
             "value" : "Errores"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7690,6 +10504,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ID de evento: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID acara: %@"
           }
         },
         "nl" : {
@@ -7709,6 +10529,12 @@
             "value" : "Ejemplo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contoh"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7723,6 +10549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Expandir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memperluas"
           }
         },
         "nl" : {
@@ -7742,6 +10574,12 @@
             "value" : "Venció"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kedaluwarsa"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7757,6 +10595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Explorar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengeksplorasi"
           }
         },
         "nl" : {
@@ -7776,6 +10620,12 @@
             "value" : "Información adicional"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informasi tambahan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7792,6 +10642,12 @@
             "state" : "translated",
             "value" : "No se pudo generar el código QR"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gagal membuat Kode QR"
+          }
         }
       }
     },
@@ -7801,6 +10657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pudo cargar la imagen"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gagal memuat gambar"
           }
         },
         "nl" : {
@@ -7820,6 +10682,12 @@
             "value" : "No se pudo cargar el video"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gagal memuat video"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7835,6 +10703,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "falló zaps"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zaps gagal"
           }
         },
         "nl" : {
@@ -7854,6 +10728,12 @@
             "value" : "Alimentar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memberi makan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7869,6 +10749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contenido del feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten umpan"
           }
         },
         "nl" : {
@@ -7887,6 +10773,12 @@
             "value" : "Opciones de alimentación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opsi umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7901,6 +10793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vista previa del feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratinjau umpan"
           }
         },
         "nl" : {
@@ -7920,6 +10818,12 @@
             "value" : "Configuración de alimentación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7935,6 +10839,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuración de alimentación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan Umpan"
           }
         },
         "nl" : {
@@ -7954,6 +10864,12 @@
             "value" : "Configuración de alimentación..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setelan umpan..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7969,6 +10885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feeds"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan"
           }
         },
         "nl" : {
@@ -7988,6 +10910,12 @@
             "value" : "Obtener recuentos en la línea de tiempo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengambilan diperhitungkan pada timeline"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8003,6 +10931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Obtiene me gusta/zaps/respuestas a medida que aparecen las publicaciones."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengambilan suka/zaps/balasan dihitung saat postingan muncul"
           }
         },
         "nl" : {
@@ -8021,6 +10955,12 @@
             "state" : "translated",
             "value" : "atractivo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mengambil"
+          }
         }
       }
     },
@@ -8030,6 +10970,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atractivo..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengambil..."
           }
         },
         "nl" : {
@@ -8046,6 +10992,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "buscarRelays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ambilRelays"
           }
         },
         "nl" : {
@@ -8065,6 +11017,12 @@
             "value" : "moneda fiduciaria"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mata uang fiat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8080,6 +11038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dirección del servidor de almacenamiento de archivos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alamat Server Penyimpanan File"
           }
         },
         "nl" : {
@@ -8098,6 +11062,12 @@
             "value" : "¡El servidor de almacenamiento de archivos se configuró correctamente!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Penyimpanan File berhasil dikonfigurasi!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8112,6 +11082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archivos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File"
           }
         },
         "nl" : {
@@ -8130,6 +11106,12 @@
             "value" : "Filtrar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyaring"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8144,6 +11126,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtra solo por tus seguidores (estricto), o también por tus seguidores (normal)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter berdasarkan pengikut Anda saja (ketat), atau juga pengikut Anda (normal)"
           }
         },
         "nl" : {
@@ -8163,6 +11151,12 @@
             "value" : "Filtrar contactos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saring kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8179,6 +11173,12 @@
             "state" : "translated",
             "value" : "carga final"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "beban akhir"
+          }
         }
       }
     },
@@ -8189,6 +11189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "encontrar autor"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan penulis"
           }
         },
         "nl" : {
@@ -8206,6 +11212,12 @@
             "state" : "translated",
             "value" : "Encuentra más conjuntos de Emoji"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan kumpulan Emoji lainnya"
+          }
         }
       }
     },
@@ -8217,6 +11229,12 @@
             "state" : "translated",
             "value" : "finalizado"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "selesai"
+          }
         }
       }
     },
@@ -8227,6 +11245,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seguir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengikuti"
           }
         },
         "nl" : {
@@ -8246,6 +11270,12 @@
             "value" : "Seguir %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8260,6 +11290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sigue a %@ en"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti %@ di"
           }
         },
         "nl" : {
@@ -8278,6 +11314,12 @@
             "value" : "Seguir todos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti semuanya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8294,6 +11336,12 @@
             "value" : "Sigue a todas las personas %lld en esta lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti semua orang %lld di daftar ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8308,6 +11356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las listas de seguimiento con un tamaño superior a este umbral se considerarán de baja calidad y no se incluirán en tu Web of Trust."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar ikuti dengan ukuran lebih tinggi dari ambang batas ini akan dianggap berkualitas rendah dan tidak disertakan dalam Web of Trust Anda"
           }
         },
         "nl" : {
@@ -8327,6 +11381,12 @@
             "value" : "Seguir paquetes y listas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti Paket & Daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8342,6 +11402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siga las sugerencias de relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ikuti petunjuk relay"
           }
         },
         "nl" : {
@@ -8360,6 +11426,12 @@
             "value" : "Seguido por"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diikuti oleh"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8374,6 +11446,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seguido por 0 personas más a las que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diikuti oleh 0 orang lain yang Anda ikuti"
           }
         },
         "nl" : {
@@ -8393,6 +11471,12 @@
             "value" : "Seguidores"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengikut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8407,6 +11491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "siguiente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mengikuti"
           }
         },
         "nl" : {
@@ -8426,6 +11516,12 @@
             "value" : "Siguiente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8440,6 +11536,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siguientes configuraciones de feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengikuti pengaturan Umpan"
           }
         },
         "nl" : {
@@ -8459,6 +11561,12 @@
             "value" : "te sigue"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengikuti Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8473,6 +11581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Botones de pie de página"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tombol catatan kaki"
           }
         },
         "nl" : {
@@ -8492,6 +11606,12 @@
             "value" : "Divertido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lucu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8506,6 +11626,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feed divertido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Lucu"
           }
         },
         "nl" : {
@@ -8525,6 +11651,12 @@
             "value" : "Galería"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Galeri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8539,6 +11671,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Periodo de tiempo de alimentación de la galería"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu umpan galeri"
           }
         },
         "nl" : {
@@ -8557,6 +11695,12 @@
             "value" : "obtener_clave_publica"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dapatkan_kunci_publik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8571,6 +11715,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "mmm roto %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "gmmm %@ rusak"
           }
         },
         "nl" : {
@@ -8589,6 +11739,12 @@
             "value" : "Ir a la transmisión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka streaming"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8603,6 +11759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verde"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hijau"
           }
         },
         "nl" : {
@@ -8622,6 +11784,12 @@
             "value" : "h"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "H"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8636,6 +11804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "la mano esta levantada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tangan terangkat"
           }
         },
         "nl" : {
@@ -8655,6 +11829,12 @@
             "value" : "Hashtag"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanda pagar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8669,6 +11849,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hashtags"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tagar"
           }
         },
         "nl" : {
@@ -8687,6 +11873,12 @@
             "state" : "translated",
             "value" : "¡Hola Mundo!"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halo Dunia!"
+          }
         }
       }
     },
@@ -8696,6 +11888,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¡Hola Mundo! ¡Hola Mundo! ¡Hola Mundo! ¡Hola Mundo! ¡Hola Mundo! Hola Mundo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halo Dunia! Halo Dunia! Halo Dunia! Halo Dunia! Halo Dunia! Halo Dunia"
           }
         },
         "nl" : {
@@ -8716,6 +11914,12 @@
             "value" : "maleficio"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "heksa"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8732,6 +11936,12 @@
             "value" : "Esconder"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bersembunyi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8746,6 +11956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ocultar teclado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sembunyikan papan ketik"
           }
         },
         "nl" : {
@@ -8765,6 +11981,12 @@
             "value" : "Ocultar publicaciones que ya has visto (beta)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sembunyikan postingan yang sudah Anda lihat (beta)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8782,6 +12004,12 @@
             "value" : "Ocultar publicaciones que ya has visto en varios dispositivos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sembunyikan postingan yang sudah Anda lihat di beberapa perangkat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8796,6 +12024,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ocultar clave privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sembunyikan kunci pribadi"
           }
         },
         "nl" : {
@@ -8816,6 +12050,12 @@
             "value" : "Ocultar barras de pestañas al desplazarse"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sembunyikan bilah tab saat menggulir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8831,6 +12071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oculta insignias de perfiles y feeds"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyembunyikan lencana dari profil dan feed"
           }
         },
         "nl" : {
@@ -8850,6 +12096,12 @@
             "value" : "Reflejos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8864,6 +12116,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hogar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rumah"
           }
         },
         "nl" : {
@@ -8882,6 +12140,12 @@
             "value" : "Inicio/Notificaciones de pantalla de bloqueo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifikasi layar Utama/Kunci"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8896,6 +12160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las notificaciones de la pantalla de inicio/bloqueo solo están activas para la cuenta actualmente iniciada y pueden retrasarse un poco"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifikasi layar Beranda/Kunci hanya aktif untuk akun yang sedang login dan mungkin sedikit tertunda"
           }
         },
         "nl" : {
@@ -8915,6 +12185,12 @@
             "value" : "Anfitrión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuan rumah"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8930,6 +12206,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caliente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Panas"
           }
         },
         "nl" : {
@@ -8948,6 +12230,12 @@
             "value" : "Periodo de tiempo de alimentación caliente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu umpan panas"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8963,6 +12251,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las noticias destacadas, Descubrir, Galería y Artículos no serán visibles si no sigues a más de 10 personas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hot, Discover, Gallery, dan Articles feed tidak akan terlihat jika Anda tidak mem-follow lebih dari 10 orang."
           }
         },
         "nl" : {
@@ -8983,6 +12277,12 @@
             "value" : "Las noticias destacadas, la galería y los artículos no serán visibles si no sigues a más de 10 personas."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hot, Gallery, dan Articles feed tidak akan terlihat jika Anda tidak mem-follow lebih dari 10 orang."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9001,6 +12301,12 @@
             "value" : "IDENTIFICACIÓN"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PENGENAL"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9015,6 +12321,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si no se puede encontrar una publicación al recibir relays, intente encontrar la publicación en este relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jika postingan pada penerimaan relays tidak dapat ditemukan, coba cari postingan pada relay ini"
           }
         },
         "nl" : {
@@ -9034,6 +12346,12 @@
             "value" : "Si el piloto automático Relay está habilitado, muestre qué relays adicional se utilizará"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jika Relay Autopilot diaktifkan, tunjukkan relays tambahan mana yang akan digunakan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9048,6 +12366,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ignorar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengabaikan"
           }
         },
         "nl" : {
@@ -9065,6 +12389,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contenido ilegal"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten ilegal"
           }
         },
         "nl" : {
@@ -9085,6 +12415,12 @@
             "value" : "Subiendo imágenes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengunggahan gambar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9102,6 +12438,12 @@
             "value" : "URL de la imagen (1024x1024)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL Gambar (1024x1024)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9116,6 +12458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imágenes"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar"
           }
         },
         "nl" : {
@@ -9135,6 +12483,12 @@
             "value" : "Interpretación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peniruan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9150,6 +12504,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Importar clave privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impor kunci pribadi"
           }
         },
         "nl" : {
@@ -9169,6 +12529,12 @@
             "value" : "en privado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "secara pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9184,6 +12550,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "incluir autor"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sertakan penulis"
           }
         },
         "nl" : {
@@ -9203,6 +12575,12 @@
             "value" : "Incluir título Nostur al compartir publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sertakan keterangan Nostur saat berbagi postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9218,6 +12596,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Incluir Nostur en los metadatos de la publicación."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sertakan Nostur dalam metadata postingan"
           }
         },
         "nl" : {
@@ -9236,6 +12620,12 @@
             "value" : "Hashtags incluidos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termasuk hashtag"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9250,6 +12640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aumentar la privacidad"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tingkatkan privasi"
           }
         },
         "nl" : {
@@ -9269,6 +12665,12 @@
             "value" : "Interacciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interaksi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9283,6 +12685,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conexión a Internet no disponible"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi internet tidak tersedia"
           }
         },
         "nl" : {
@@ -9302,6 +12710,12 @@
             "value" : "Clave no válida"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci tidak valid"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9319,6 +12733,12 @@
             "value" : "Clave privada no válida"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci pribadi tidak valid"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9333,6 +12753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Está marcado como favorito: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditandai: %@"
           }
         },
         "nl" : {
@@ -9352,6 +12778,12 @@
             "value" : "Emitido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterbitkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9368,6 +12800,12 @@
             "value" : "Parece que los contactos de %lld se eliminaron de su siguiente lista, tal vez de otra aplicación nostr%@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sepertinya kontak %lld telah dihapus dari daftar berikut Anda, mungkin dari aplikasi nostr lain%@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9382,6 +12820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Depende de relays y otras aplicaciones cumplir con su solicitud"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terserah relays dan aplikasi lain untuk memenuhi permintaan Anda"
           }
         },
         "nl" : {
@@ -9401,6 +12845,12 @@
             "value" : "En este momento"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "baru saja"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9415,6 +12865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mantenga su mensaje breve"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jaga agar pesan Anda tetap singkat"
           }
         },
         "nl" : {
@@ -9434,6 +12890,12 @@
             "value" : "Realiza un seguimiento de todas las publicaciones de feeds que ya has visto, no las vuelves a mostrar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lacak semua postingan feed yang telah Anda lihat, jangan tampilkan lagi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9448,6 +12910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Llaves"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci"
           }
         },
         "nl" : {
@@ -9467,6 +12935,12 @@
             "value" : "kind %@ aún no compatible"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kind %@ belum didukung"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9481,6 +12955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "tipo: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "jenis: %@"
           }
         },
         "nl" : {
@@ -9499,6 +12979,12 @@
             "state" : "translated",
             "value" : "Paisaje"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lanskap"
+          }
         }
       }
     },
@@ -9508,6 +12994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Última 1 hora"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 jam terakhir"
           }
         },
         "nl" : {
@@ -9526,6 +13018,12 @@
             "value" : "últimos 5 minutos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 menit terakhir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9540,6 +13038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Últimos 10 mensajes de error"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 pesan kesalahan terakhir"
           }
         },
         "nl" : {
@@ -9558,6 +13062,12 @@
             "value" : "Últimos 10 mensajes de aviso"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 pesan pemberitahuan terakhir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9572,6 +13082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "últimos 15 minutos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15 menit terakhir"
           }
         },
         "nl" : {
@@ -9591,6 +13107,12 @@
             "value" : "Última optimización: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optimasi terakhir: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9608,6 +13130,12 @@
             "value" : "Visto por última vez: hace %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terakhir terlihat: %@ lalu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9622,6 +13150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Última actualización %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ yang terakhir diperbarui"
           }
         },
         "nl" : {
@@ -9641,6 +13175,12 @@
             "value" : "Última actualización: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terakhir diperbarui: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9656,6 +13196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Última actualización: 27 de mayo de 2023\n    \nSu acceso y uso de la Aplicación está condicionado a su aceptación y cumplimiento de estos Términos. Estos Términos se aplican a todos los usuarios de la Aplicación.\n\nAl acceder o utilizar la Aplicación, usted acepta estar sujeto a estos Términos. Si no está de acuerdo con alguna parte de los términos, entonces no tiene permiso para acceder a la aplicación.\n\nCuentas\nCuando crea una cuenta con la Aplicación, usted es responsable de mantener la confidencialidad de las claves de su cuenta, así como de restringir el acceso a su dispositivo. Usted acepta aceptar la responsabilidad de todas y cada una de las actividades o acciones que ocurran en su cuenta.\n\nContenido\nLa aplicación le permite acceder, leer y publicar contenido conectándose a relays. Usted es responsable del contenido que publica o al que accede a través de la Aplicación, incluida su legalidad, confiabilidad e idoneidad.\n\nAl publicar contenido a través de la Aplicación, usted declara y garantiza que el contenido es suyo (usted es dueño de él) y/o tiene derecho a usarlo, y que la publicación de su contenido a través de la Aplicación no viola los derechos de privacidad, derechos de publicidad, derechos de autor, derechos contractuales o cualquier otro derecho de cualquier persona o entidad.\n\nActividades prohibidas\nUsted acepta no utilizar la aplicación para actividades ilegales, dañinas u ofensivas, incluidas, entre otras:\n\nParticipar en acoso, intimidación o cualquier forma de intimidación.\nDistribuir o promover material sexualmente explícito o pornográfico.\nPromover discursos de odio, racismo o discriminación de cualquier tipo.\nInfringir los derechos de propiedad intelectual de otros\nParticipar en cualquier forma de fraude, phishing o recopilación de datos no autorizada\nPropiedad Intelectual\nLa Aplicación y su contenido original (excluido el Contenido proporcionado por los usuarios), características y funcionalidades son y seguirán siendo propiedad exclusiva del Desarrollador. La aplicación está protegida por derechos de autor, marcas registradas y otras leyes de los Estados Unidos y países extranjeros. No se pueden utilizar marcas comerciales ni imágenes comerciales en relación con ningún producto o servicio sin el consentimiento previo por escrito del Desarrollador.\n\nLimitación de responsabilidad\nEn ningún caso el Desarrollador será responsable de daños indirectos, incidentales, especiales, consecuentes o punitivos, incluidos, entre otros, pérdida de ganancias, datos, uso, buena voluntad u otras pérdidas intangibles, que resulten de (i) su acceso o uso o incapacidad para acceder o utilizar la Aplicación; (ii) cualquier conducta o contenido de cualquier tercero en la Aplicación; (iii) cualquier contenido obtenido de la Aplicación; y (iv) acceso no autorizado, uso o alteración de sus transmisiones o contenido, ya sea basado en garantía, contrato, agravio (incluida la negligencia) o cualquier otra teoría legal, ya sea que el Desarrollador haya sido informado o no de la posibilidad de dicho daño, e incluso si se determina que un remedio establecido en este documento no ha cumplido su propósito esencial.\n\nPolítica de privacidad\nNostur no recopila información sobre usted. La aplicación almacena la información que usted proporciona sobre su perfil nostr, que puede ser cualquier cosa que elija compartir o no. Las publicaciones y el contenido que comparte desde Nostur se envían al relays público para que cualquiera pueda verlos y Nostur los almacena en su dispositivo para que siempre pueda verlos usted mismo.\nLa aplicación utiliza los siguientes servicios externos:\nTenor: por incluir GIF animados en tus publicaciones\nServicios de carga de imágenes: Para incluir imágenes en tus publicaciones. Puede optar por no utilizar estos servicios al no incluir imágenes o GIF en sus publicaciones y no cargar una imagen de perfil o un banner en la aplicación.\n\nSi tiene alguna pregunta, comuníquese con feedback@nostur.com."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terakhir diperbarui: 27 Mei 2023\n    \nAkses Anda ke dan penggunaan Aplikasi dikondisikan pada penerimaan dan kepatuhan Anda terhadap Ketentuan ini. Ketentuan ini berlaku untuk semua pengguna Aplikasi.\n\nDengan mengakses atau menggunakan Aplikasi, Anda setuju untuk terikat oleh Ketentuan ini. Jika Anda tidak setuju dengan bagian mana pun dari ketentuan ini, maka Anda tidak memiliki izin untuk mengakses Aplikasi.\n\nAkun\nSaat Anda membuat akun dengan Aplikasi, Anda bertanggung jawab untuk menjaga kerahasiaan kunci akun Anda, serta membatasi akses ke perangkat Anda. Anda setuju untuk menerima tanggung jawab atas setiap dan seluruh aktivitas atau tindakan yang terjadi dalam akun Anda.\n\nKonten\nAplikasi ini memungkinkan Anda mengakses, membaca, dan memposting konten melalui koneksi ke relays. Anda bertanggung jawab atas konten yang Anda posting atau akses melalui Aplikasi, termasuk legalitas, keandalan, dan kesesuaiannya.\n\nDengan memposting konten melalui Aplikasi, Anda menyatakan dan menjamin bahwa konten tersebut adalah milik Anda (Anda adalah pemiliknya) dan/atau Anda mempunyai hak untuk menggunakannya, dan bahwa postingan konten Anda melalui Aplikasi tidak melanggar hak privasi, hak publisitas, hak cipta, hak kontrak, atau hak lain apa pun dari orang atau entitas mana pun.\n\nKegiatan yang Dilarang\nAnda setuju untuk tidak menggunakan Aplikasi untuk aktivitas ilegal, berbahaya, atau menyinggung, termasuk namun tidak terbatas pada:\n\nTerlibat dalam pelecehan, intimidasi, atau segala bentuk intimidasi\nMendistribusikan atau mempromosikan materi seksual eksplisit atau pornografi\nMempromosikan ujaran kebencian, rasisme, atau diskriminasi dalam bentuk apa pun\nMelanggar hak kekayaan intelektual orang lain\nTerlibat dalam segala bentuk penipuan, phishing, atau pengumpulan data tanpa izin\nKekayaan Intelektual\nAplikasi dan konten aslinya (tidak termasuk Konten yang disediakan oleh pengguna), fitur, dan fungsionalitasnya adalah dan akan tetap menjadi milik eksklusif Pengembang. Aplikasi ini dilindungi oleh hak cipta, merek dagang, dan undang-undang lain di Amerika Serikat dan negara asing. Merek dagang dan tampilan dagang apa pun tidak boleh digunakan sehubungan dengan produk atau layanan apa pun tanpa izin tertulis sebelumnya dari Pengembang.\n\nBatasan Tanggung Jawab\nDalam keadaan apa pun, Pengembang tidak bertanggung jawab atas kerugian tidak langsung, insidental, khusus, konsekuensial, atau hukuman, termasuk namun tidak terbatas pada, hilangnya keuntungan, data, penggunaan, niat baik, atau kerugian tidak berwujud lainnya, yang diakibatkan oleh (i) akses Anda ke atau penggunaan atau ketidakmampuan untuk mengakses atau menggunakan Aplikasi; (ii) segala perilaku atau konten pihak ketiga mana pun di Aplikasi; (iii) konten apa pun yang diperoleh dari Aplikasi; dan (iv) akses, penggunaan, atau perubahan tidak sah atas transmisi atau konten Anda, baik berdasarkan jaminan, kontrak, kesalahan (termasuk kelalaian), atau teori hukum lainnya, baik Pengembang telah diberitahu atau tidak mengenai kemungkinan kerusakan tersebut, dan bahkan jika upaya hukum yang ditetapkan di sini ternyata gagal mencapai tujuan utamanya.\n\nKebijakan Privasi\nNostur tidak mengumpulkan informasi tentang Anda. Aplikasi ini menyimpan informasi yang Anda berikan tentang profil nostr Anda, bisa berupa apa pun yang Anda pilih untuk dibagikan atau tidak. Pos dan konten yang Anda bagikan dari Nostur dikirim ke relays publik sehingga siapa pun dapat melihatnya dan Nostur menyimpannya di perangkat Anda sehingga Anda selalu dapat melihatnya sendiri.\nAplikasi ini menggunakan layanan eksternal berikut:\nTenor: untuk menyertakan GIF animasi di postingan Anda\nLayanan unggah gambar: Untuk menyertakan gambar dalam postingan Anda. Anda dapat memilih untuk tidak menggunakan layanan ini dengan tidak menyertakan gambar atau GIF di postingan Anda dan tidak mengunggah gambar profil atau spanduk di aplikasi.\n\nUntuk pertanyaan apa pun, silakan hubungi feedback@nostur.com."
           }
         },
         "nl" : {
@@ -9674,6 +13220,12 @@
             "value" : "Dejar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meninggalkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9690,6 +13242,12 @@
             "value" : "Menos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lebih sedikit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9704,6 +13262,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Informe a otros en qué servidores se pueden encontrar sus medios"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beri tahu orang lain di server mana media Anda dapat ditemukan"
           }
         },
         "nl" : {
@@ -9723,6 +13287,12 @@
             "value" : "¡Vamos!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayo pergi!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9740,6 +13310,12 @@
             "value" : "Permite que otros sepan que estás publicando desde Nostur"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beri tahu orang lain bahwa Anda memposting dari Nostur"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9752,6 +13328,12 @@
       "comment" : "Label for entering a Lightning Address on Edit Profile screen",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lightning Address (LUD-06/16)"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lightning Address (LUD-06/16)"
@@ -9774,6 +13356,12 @@
             "value" : "Efecto de sonido Lightning"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Efek suara Lightning"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9791,6 +13379,12 @@
             "value" : "billetera Lightning"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dompet Lightning"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9806,6 +13400,12 @@
             "state" : "translated",
             "value" : "Me gusta"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suka"
+          }
         }
       }
     },
@@ -9817,6 +13417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gustos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suka"
           }
         },
         "nl" : {
@@ -9835,6 +13441,12 @@
             "value" : "Limitar tipos de contenido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batasi tipe konten"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9849,6 +13461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite las notificaciones de la pantalla de inicio/bloqueo solo de las personas que sigue"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batasi notifikasi Layar Utama/Kunci hanya dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -9867,6 +13485,12 @@
             "value" : "Enlace"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Link"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9881,6 +13505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lista"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar"
           }
         },
         "nl" : {
@@ -9899,6 +13529,12 @@
             "value" : "Nombre de la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nama daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9913,6 +13549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Escuche anónimamente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dengarkan secara anonim"
           }
         },
         "nl" : {
@@ -9932,6 +13574,12 @@
             "value" : "Listas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9947,6 +13595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Listas y feeds"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar & Umpan"
           }
         },
         "nl" : {
@@ -9966,6 +13620,12 @@
             "value" : "Listas y paquetes de seguimiento"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar & Ikuti Paket"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9980,6 +13640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Listas creadas por personas a las que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar yang dibuat oleh orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -9999,6 +13665,12 @@
             "value" : "Listas de personas que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar dari orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10013,6 +13685,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nidos en vivo o transmisiones de lo siguiente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sarang Langsung atau streaming dari berikut"
           }
         },
         "nl" : {
@@ -10032,6 +13710,12 @@
             "value" : "Transmisiones en vivo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streaming Langsung"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10046,6 +13730,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Transmisiones en vivo de personas que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streaming Langsung dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -10065,6 +13755,12 @@
             "value" : "Cargar de todos modos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tetap muat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10079,6 +13775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cargar predeterminado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muat bawaan"
           }
         },
         "nl" : {
@@ -10097,6 +13799,12 @@
             "value" : "Cargar preajuste 1"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat preset 1"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10111,6 +13819,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cargar preajuste 2"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat preset 2"
           }
         },
         "nl" : {
@@ -10129,6 +13843,12 @@
             "value" : "Cargar preajuste 3"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat preset 3"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10143,6 +13863,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cargar preajuste 4"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat preset 4"
           }
         },
         "nl" : {
@@ -10160,6 +13886,12 @@
             "state" : "translated",
             "value" : "Cargando conjuntos de emojis…"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat kumpulan emoji…"
+          }
         }
       }
     },
@@ -10170,6 +13902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indicador de carga"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indikator pemuatan"
           }
         },
         "nl" : {
@@ -10189,6 +13927,12 @@
             "value" : "Carga en pausa (modo de datos bajos)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pemuatan dijeda (Mode data rendah)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10204,6 +13948,12 @@
             "state" : "translated",
             "value" : "Cargando..."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memuat..."
+          }
         }
       }
     },
@@ -10213,6 +13963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquear publicación en %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci posting ke %@"
           }
         },
         "nl" : {
@@ -10232,6 +13988,12 @@
             "value" : "Cerrar sesión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keluar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10246,6 +14008,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Solicitud de inicio de sesión"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permintaan masuk"
           }
         },
         "nl" : {
@@ -10264,6 +14032,12 @@
             "value" : "Cerrar sesión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keluar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10278,6 +14052,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Artículos extensos de personas a las que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artikel panjang dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -10298,6 +14078,12 @@
             "value" : "Modo de datos bajos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode Data Rendah"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10313,6 +14099,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modo de datos bajos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modus Data Rendah"
           }
         },
         "nl" : {
@@ -10332,6 +14124,12 @@
             "value" : "metro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "M"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10346,6 +14144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "cuenta principal"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun utama"
           }
         },
         "nl" : {
@@ -10366,6 +14170,12 @@
             "value" : "WoT principal"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WoT Utama"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10381,6 +14191,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mantenido por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dikelola oleh"
           }
         },
         "nl" : {
@@ -10400,6 +14216,12 @@
             "value" : "Hacer pública la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jadikan daftar menjadi publik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10414,6 +14236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hacer moderador"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jadikan moderator"
           }
         },
         "nl" : {
@@ -10434,6 +14262,12 @@
             "value" : "Asegúrese de tener una copia de seguridad de su clave privada (nsec)\nNostur no puede recuperar su cuenta sin él"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastikan Anda memiliki cadangan kunci pribadi Anda (nsec)\nNostur tidak dapat memulihkan akun Anda tanpanya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10449,6 +14283,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Asegúrese de tener una copia de seguridad de su clave privada (nsec). Nostur no puede recuperar su cuenta sin él."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastikan Anda memiliki cadangan kunci pribadi Anda (nsec). Nostur tidak dapat memulihkan akun Anda tanpanya."
           }
         },
         "nl" : {
@@ -10468,6 +14308,12 @@
             "value" : "Marcar todo como leído"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tandai semua sebagai telah dibaca"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10484,6 +14330,12 @@
             "value" : "Máximo 6 segundos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maks 6 detik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10498,6 +14350,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Es posible que sea necesario acceder a funciones especiales en este relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mungkin diperlukan untuk mengakses fitur khusus pada relay ini"
           }
         },
         "nl" : {
@@ -10517,6 +14375,12 @@
             "value" : "Medios de comunicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10532,6 +14396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caché de medios"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tembolok media"
           }
         },
         "nl" : {
@@ -10551,6 +14421,12 @@
             "value" : "Descarga de medios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengunduhan media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10565,6 +14441,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Medios de publicaciones de cualquier persona que más les gusten o que las personas que sigues vuelven a publicar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media dari postingan siapa pun yang paling disukai atau di-repost oleh orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -10582,6 +14464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Medios de las publicaciones que más me gustaron o que las personas que sigues volvieron a publicar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media dari postingan yang paling disukai atau di-repost oleh orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -10602,6 +14490,12 @@
             "value" : "Servicio de carga de medios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Layanan pengunggahan media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10619,6 +14513,12 @@
             "value" : "Carga de medios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengunggahan media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10633,6 +14533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mencionado por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disebutkan oleh"
           }
         },
         "nl" : {
@@ -10652,6 +14558,12 @@
             "value" : "menciona"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menyebutkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10669,6 +14581,12 @@
             "value" : "Menciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sebutan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10683,6 +14601,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menciones, respuestas, DM y nuevas publicaciones."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sebutan, balasan, DM, dan postingan baru"
           }
         },
         "nl" : {
@@ -10702,6 +14626,12 @@
             "value" : "Menciones, respuestas o DM"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sebutan, balasan, atau DM"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10718,6 +14648,12 @@
             "value" : "Entrega de mensajes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengiriman Pesan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10732,6 +14668,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Formato de mensaje"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format pesan"
           }
         },
         "nl" : {
@@ -10751,6 +14693,12 @@
             "value" : "Verificación de mensajes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifikasi pesan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10766,6 +14714,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mensajes"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan"
           }
         },
         "nl" : {
@@ -10784,6 +14738,12 @@
             "value" : "Los mensajes se envían utilizando un protocolo de cifrado antiguo porque el mensaje privado del destinatario relays no se ha publicado o no se ha podido encontrar."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan dikirim menggunakan protokol enkripsi lama karena pesan pribadi penerima relays belum dipublikasikan atau tidak dapat ditemukan."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10798,6 +14758,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Los mensajes se envían utilizando un protocolo de cifrado más antiguo."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan dikirim menggunakan protokol enkripsi yang lebih lama."
           }
         },
         "nl" : {
@@ -10816,6 +14782,12 @@
             "value" : "El micrófono está apagado."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mikrofon mati"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10832,6 +14804,12 @@
             "value" : "El micrófono está encendido."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mikrofon aktif"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10846,6 +14824,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimizar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memperkecil"
           }
         },
         "nl" : {
@@ -10865,6 +14849,12 @@
             "value" : "¿Faltan mensajes?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan hilang?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10879,6 +14869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¿Mensajes faltantes?"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan hilang?"
           }
         },
         "nl" : {
@@ -10897,6 +14893,12 @@
             "state" : "translated",
             "value" : "Falta nrLiveEvent"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada nrLiveEvent"
+          }
         }
       }
     },
@@ -10908,6 +14910,12 @@
             "state" : "translated",
             "value" : "Falta respuesta."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balasan tidak ada."
+          }
         }
       }
     },
@@ -10917,6 +14925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actualización simulada de marcadores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pembaruan Bookmark Tiruan"
           }
         },
         "nl" : {
@@ -10936,6 +14950,12 @@
             "value" : "Actualización de perfil simulado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pembaruan Profil Mock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10951,6 +14971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Moderador"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "moderator"
           }
         },
         "nl" : {
@@ -10969,6 +14995,12 @@
             "value" : "Mes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bulan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10983,6 +15015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Más"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lagi"
           }
         },
         "nl" : {
@@ -11003,6 +15041,12 @@
             "value" : "Más recibidos recientemente en"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paling banyak diterima baru-baru ini pada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11017,6 +15061,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Varias columnas y más"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multi-kolom dan banyak lagi"
           }
         },
         "nl" : {
@@ -11036,6 +15086,12 @@
             "value" : "Silenciar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bisu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11051,6 +15107,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Silenciar conversación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bisukan percakapan"
           }
         },
         "nl" : {
@@ -11069,6 +15131,12 @@
             "value" : "Silenciar micrófono"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bisukan mikrofon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11084,6 +15152,12 @@
             "state" : "translated",
             "value" : "Silenciar vídeo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bisukan video"
+          }
         }
       }
     },
@@ -11094,6 +15168,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conversaciones silenciadas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percakapan yang dibungkam"
           }
         },
         "nl" : {
@@ -11113,6 +15193,12 @@
             "value" : "Palabras silenciadas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kata-kata yang dibungkam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11128,6 +15214,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nombre"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nama"
           }
         },
         "nl" : {
@@ -11146,6 +15238,12 @@
             "value" : "CAROLINA DEL NORTE"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tidak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11158,6 +15256,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NColumnFeedView"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NColumnFeedView"
@@ -11179,6 +15283,12 @@
             "value" : "Título del nido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Judul sarang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11193,6 +15303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Servidor de audio Nest"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server Audio Sarang"
           }
         },
         "nl" : {
@@ -11211,6 +15327,12 @@
             "value" : "Servidor de nidos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server sarang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11225,6 +15347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Servidor de nidos:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server sarang:"
           }
         },
         "nl" : {
@@ -11244,6 +15372,12 @@
             "value" : "Los nidos se anunciarán el:"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sarang akan diumumkan pada:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11260,6 +15394,12 @@
             "value" : "Nunca te conectes a este relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jangan pernah terhubung ke relay ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11274,6 +15414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nueva lista de contactos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan daftar kontak baru"
           }
         },
         "nl" : {
@@ -11294,6 +15440,12 @@
             "value" : "Nuevo mensaje directo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan langsung baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11311,6 +15463,12 @@
             "value" : "Nueva alimentación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11325,6 +15483,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nueva fuente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Baru"
           }
         },
         "nl" : {
@@ -11344,6 +15508,12 @@
             "value" : "Nuevo feed de contactos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan baru dari kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11360,6 +15530,12 @@
             "value" : "Nueva fuente..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Baru..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11374,6 +15550,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las notificaciones de nuevos seguidores aparecerán aquí."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifikasi pengikut baru akan muncul di sini"
           }
         },
         "nl" : {
@@ -11393,6 +15575,12 @@
             "value" : "nuevos seguidores"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pengikut baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11407,6 +15595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevos seguidores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengikut baru"
           }
         },
         "nl" : {
@@ -11425,6 +15619,12 @@
             "value" : "Nuevo nombre de lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nama daftar baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11439,6 +15639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nueva lista..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar baru..."
           }
         },
         "nl" : {
@@ -11459,6 +15665,12 @@
             "value" : "Nuevo mensaje"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11473,6 +15685,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevo mensaje"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan Baru"
           }
         },
         "nl" : {
@@ -11492,6 +15710,12 @@
             "value" : "Nueva publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11506,6 +15730,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nueva publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan Baru"
           }
         },
         "nl" : {
@@ -11525,6 +15755,12 @@
             "value" : "nuevas publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "posting baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11539,6 +15775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevas publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan baru"
           }
         },
         "nl" : {
@@ -11558,6 +15800,12 @@
             "value" : "Nuevas publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan Baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11572,6 +15820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevas publicaciones de %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan baru dari %@"
           }
         },
         "nl" : {
@@ -11591,6 +15845,12 @@
             "value" : "Nueva nota privada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan pribadi baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11605,6 +15865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevas reacciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reaksi baru"
           }
         },
         "nl" : {
@@ -11624,6 +15890,12 @@
             "value" : "Nuevo feed de relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan relay baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11638,6 +15910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevas publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repost baru"
           }
         },
         "nl" : {
@@ -11656,6 +15934,12 @@
             "value" : "Nuevo vídeo corto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video Pendek Baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11670,6 +15954,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuevo mensaje de voz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan Suara Baru"
           }
         },
         "nl" : {
@@ -11688,6 +15978,12 @@
             "value" : "Nuevo zaps"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zaps baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11704,6 +16000,12 @@
             "state" : "translated",
             "value" : "nuevasPublicaciones"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting baru"
+          }
         }
       }
     },
@@ -11713,6 +16015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Próximo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berikutnya"
           }
         },
         "nl" : {
@@ -11732,6 +16040,12 @@
             "value" : "Niks"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11747,6 +16061,12 @@
             "state" : "translated",
             "value" : "No se encontró ninguna cuenta Nostr activa. Primero inicie sesión en Nostur."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ditemukan akun Nostr aktif. Silakan masuk ke Nostur terlebih dahulu."
+          }
         }
       }
     },
@@ -11756,6 +16076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se encontraron artículos de su lista de seguimiento en el período de tiempo seleccionado."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada artikel yang ditemukan dari daftar ikuti Anda dalam jangka waktu yang dipilih."
           }
         },
         "nl" : {
@@ -11773,6 +16099,12 @@
             "state" : "translated",
             "value" : "No hay ningún servidor Blossom configurado. Configure un servidor Blossom en la configuración de Nostur para cargar imágenes."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada server Blossom yang dikonfigurasi. Harap konfigurasikan server Blossom di pengaturan Nostur untuk mengunggah gambar."
+          }
         }
       }
     },
@@ -11782,6 +16114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se encontraron comentarios."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada komentar yang ditemukan."
           }
         },
         "nl" : {
@@ -11799,6 +16137,12 @@
             "state" : "translated",
             "value" : "No se encontraron etiquetas emoji personalizadas en este conjunto."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada tag emoji khusus yang ditemukan di kumpulan ini."
+          }
         }
       }
     },
@@ -11808,6 +16152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se encontró DM relays para"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ditemukan DM relays"
           }
         },
         "nl" : {
@@ -11827,6 +16177,12 @@
             "value" : "Sin conexión a internet"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada koneksi internet"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11844,6 +16200,12 @@
             "value" : "No hay solicitudes de mensajes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada permintaan pesan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11858,6 +16220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aún no se han recopilado estadísticas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Belum ada statistik yang dikumpulkan."
           }
         },
         "nl" : {
@@ -11877,6 +16245,12 @@
             "value" : "medios no https bloqueados"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "media non-https diblokir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11893,6 +16267,12 @@
             "value" : "Ninguno"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11907,6 +16287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cuenta Nostr"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun Nostr"
           }
         },
         "nl" : {
@@ -11926,6 +16312,12 @@
             "value" : "Dirección Nostr (NIP-05)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alamat Nostr (NIP-05)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11941,6 +16333,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dirección nostr / npub / nsec / URL del firmante"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alamat nostr / npub / nsec / url penandatangan"
           }
         },
         "nl" : {
@@ -11959,6 +16357,12 @@
             "value" : "Nostr Número de Dunbar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nomor Dunbar Nostr"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11973,6 +16377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Evento Nostr"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "acara Nostr"
           }
         },
         "nl" : {
@@ -11991,6 +16401,12 @@
             "value" : "Eventos Nostr:"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acara Nostr:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12002,6 +16418,12 @@
     "Nostr ID" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID Nostr"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ID Nostr"
@@ -12024,6 +16446,12 @@
             "value" : "Conexión de billetera Nostr"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi Dompet Nostr"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12039,6 +16467,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nostr URI de conexión de billetera"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dompet Nostr Menghubungkan URI"
           }
         },
         "nl" : {
@@ -12063,6 +16497,12 @@
             "value" : "Nostur %1$@ (compilación: %2$@)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nostur %1$@ (Bangun: %2$@)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12080,6 +16520,12 @@
             "value" : "Nostur no tiene permisos para configurar un recordatorio"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nostur tidak memiliki izin untuk menyetel pengingat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12092,6 +16538,12 @@
       "comment" : "Setting on settings screen",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nostur Pro"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nostur Pro"
@@ -12115,6 +16567,12 @@
             "value" : "Nostur Pro (Beta)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nostur Pro (Beta)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12130,6 +16588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aún no"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Belum"
           }
         },
         "nl" : {
@@ -12150,6 +16614,12 @@
             "value" : "Nota: El contenido de los mensajes directos está cifrado, pero los metadatos no. A quién le envías un mensaje y cuándo es público."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan: Konten DM dienkripsi tetapi metadatanya tidak. Kepada siapa Anda mengirim pesan dan kapan bersifat publik."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12165,6 +16635,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nota: También puedes agregar la clave pública de otra persona para probar Nostur desde su perspectiva."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan: Anda juga dapat menambahkan kunci publik orang lain untuk mencoba Nostur dari sudut pandang mereka."
           }
         },
         "nl" : {
@@ -12184,6 +16660,12 @@
             "value" : "Nada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12199,6 +16681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se encontró nada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada yang ditemukan"
           }
         },
         "nl" : {
@@ -12217,6 +16705,12 @@
             "value" : "Aquí nada :("
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak ada apa pun di sini :("
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12233,6 +16727,12 @@
             "value" : "Avisos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pemberitahuan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12247,6 +16747,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuración de notificaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan notifikasi"
           }
         },
         "nl" : {
@@ -12266,6 +16772,12 @@
             "value" : "Notificaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pemberitahuan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12280,6 +16792,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuración de notificaciones..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setelan notifikasi..."
           }
         },
         "nl" : {
@@ -12298,6 +16816,12 @@
             "value" : "Notificar selección (%lld)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beritahu pilihan (%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12312,6 +16836,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ahora usando:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sekarang menggunakan:"
           }
         },
         "nl" : {
@@ -12331,6 +16861,12 @@
             "value" : "nsecBunker appears offline, post will be saved but not published"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nsecBunker appears offline, post will be saved but not published"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12342,6 +16878,12 @@
     "NSFW" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NSFW"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NSFW"
@@ -12364,6 +16906,12 @@
             "value" : "Desnudez"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketelanjangan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12375,6 +16923,12 @@
     "NWC" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NWC"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NWC"
@@ -12396,6 +16950,12 @@
             "value" : "Apagado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mati"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12410,6 +16970,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DE ACUERDO"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OKE"
           }
         },
         "nl" : {
@@ -12428,6 +16994,12 @@
             "value" : "En"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12442,6 +17014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conéctese solo a relays adicional cuando una VPN esté activa"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya sambungkan ke relays tambahan saat VPN aktif"
           }
         },
         "nl" : {
@@ -12460,6 +17038,12 @@
             "value" : "Solo para personas donde hayas activado la campana de notificaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya untuk orang yang sudah mengaktifkan lonceng notifikasinya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12474,6 +17058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sólo de lo siguiente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya dari berikut ini"
           }
         },
         "nl" : {
@@ -12492,6 +17082,12 @@
             "value" : "Mostrar solo contenido de tus seguidores o seguidores-sigue"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya tampilkan konten dari follow atau follow-follow Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12506,6 +17102,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abrir en %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka di %@"
           }
         },
         "nl" : {
@@ -12525,6 +17127,12 @@
             "value" : "Abrir más reciente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka terbaru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12541,6 +17149,12 @@
             "state" : "translated",
             "value" : "Abrir configuración"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka Pengaturan"
+          }
         }
       }
     },
@@ -12550,6 +17164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "abrir con"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka dengan"
           }
         },
         "nl" : {
@@ -12569,6 +17189,12 @@
             "value" : "Optimizar ahora"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optimalkan sekarang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12584,6 +17210,12 @@
             "state" : "translated",
             "value" : "Imágenes opcionales para adjuntar al post. Requiere que se configure un servidor Blossom en la configuración de Nostur."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar opsional untuk dilampirkan ke postingan. Membutuhkan server Blossom untuk dikonfigurasi dalam pengaturan Nostur."
+          }
         }
       }
     },
@@ -12594,6 +17226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "O salta y prueba primero como invitado."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atau, lewati dan coba sebagai tamu terlebih dahulu"
           }
         },
         "nl" : {
@@ -12612,6 +17250,12 @@
             "value" : "Naranja"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oranye"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12626,6 +17270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Otro"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lainnya"
           }
         },
         "nl" : {
@@ -12645,6 +17295,12 @@
             "value" : "El feed de indignación puede o no estar disponible en una versión futura"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan kemarahan mungkin tersedia atau tidak tersedia di rilis mendatang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12659,6 +17315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PAG"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P"
           }
         },
         "nl" : {
@@ -12677,6 +17339,12 @@
             "state" : "translated",
             "value" : "Pasta"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasta"
+          }
         }
       }
     },
@@ -12687,6 +17355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pagar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membayar"
           }
         },
         "nl" : {
@@ -12703,6 +17377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intento de pago"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pembayaran dicoba"
           }
         },
         "nl" : {
@@ -12722,6 +17402,12 @@
             "value" : "PFP está aquí (máximo 10)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PFP ada di sini (maks 10)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12737,6 +17423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fotos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Foto"
           }
         },
         "nl" : {
@@ -12755,6 +17447,12 @@
             "value" : "Configuración del feed de fotos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan Umpan Foto"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12769,6 +17467,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elige GIF"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih GIF"
           }
         },
         "nl" : {
@@ -12787,6 +17491,12 @@
             "value" : "Elegir foto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Foto"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12801,6 +17511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elegir vídeo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Video"
           }
         },
         "nl" : {
@@ -12819,6 +17535,12 @@
             "state" : "translated",
             "value" : "Imagen en imagen"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar-dalam-gambar"
+          }
         }
       }
     },
@@ -12830,6 +17552,12 @@
             "state" : "translated",
             "value" : "Imagen en imagen"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar-dalam-Gambar"
+          }
         }
       }
     },
@@ -12840,6 +17568,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Los feeds de Solo imágenes, Populares, Descubrir, Galería y Artículos no serán visibles si no sigues a más de 10 personas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Gambar saja, Hot, Temukan, Galeri, dan Artikel tidak akan terlihat jika Anda tidak mengikuti lebih dari 10 orang."
           }
         },
         "nl" : {
@@ -12859,6 +17593,12 @@
             "value" : "Solo imágenes, Yaks, diVines, Hot, Discover, Gallery y Articles no serán visibles si no sigues a más de 10 personas."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Gambar saja, Yaks, diVines, Hot, Discover, Gallery, dan Articles tidak akan terlihat jika Anda tidak mengikuti lebih dari 10 orang."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12874,6 +17614,12 @@
             "state" : "translated",
             "value" : "Solo imágenes, Yaks, Divines, Hot, Discover, Gallery y Articles no serán visibles si no sigues a más de 10 personas."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Gambar saja, Yaks, Divines, Hot, Discover, Gallery, dan Articles tidak akan terlihat jika Anda tidak mengikuti lebih dari 10 orang."
+          }
         }
       }
     },
@@ -12884,6 +17630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Los feeds de imágenes, novedades, descubrimientos, galería y artículos no serán visibles si no sigues a más de 10 personas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feed Gambar, Hot, Discover, Gallery, dan Artikel tidak akan terlihat jika Anda tidak mengikuti lebih dari 10 orang."
           }
         },
         "nl" : {
@@ -12900,6 +17652,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fotos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar"
           }
         },
         "nl" : {
@@ -12919,6 +17677,12 @@
             "value" : "Fotos de personas que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar dari orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12933,6 +17697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feed de solo imágenes de las personas que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan hanya gambar dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -12951,6 +17721,12 @@
             "value" : "Alfiler"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12965,6 +17741,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fijar feed como pestaña"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sematkan umpan sebagai tab"
           }
         },
         "nl" : {
@@ -12984,6 +17766,12 @@
             "value" : "Pin en la barra de pestañas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sematkan pada bilah tab"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12998,6 +17786,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anclar el feed relay como pestaña"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sematkan umpan relay sebagai tab"
           }
         },
         "nl" : {
@@ -13017,6 +17811,12 @@
             "value" : "Fijar esta publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sematkan postingan ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13032,6 +17832,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fijar en tu perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sematkan ke profil Anda"
           }
         },
         "nl" : {
@@ -13050,6 +17856,12 @@
             "value" : "Rosa"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berwarna merah muda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13064,6 +17876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fijado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disematkan"
           }
         },
         "nl" : {
@@ -13083,6 +17901,12 @@
             "value" : "Lea atentamente estos Términos y condiciones (\"Términos\", \"Términos y condiciones\") antes de utilizar Nostur (la \"Aplicación\") operada por el desarrollador independiente (\"Desarrollador\")."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harap baca Syarat dan Ketentuan ini (\"Syarat\", \"Syarat dan Ketentuan\") dengan cermat sebelum menggunakan Nostur (\"Aplikasi\") yang dioperasikan oleh pengembang independen (\"Pengembang\")."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13097,6 +17921,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inténtalo de nuevo cuando haya una conexión."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silakan coba lagi ketika ada koneksi"
           }
         },
         "nl" : {
@@ -13115,6 +17945,12 @@
             "state" : "translated",
             "value" : "Apunta tu cámara al código QR NWC de tu billetera"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arahkan kamera Anda ke kode QR NWC dompet Anda"
+          }
         }
       }
     },
@@ -13126,6 +17962,12 @@
             "state" : "translated",
             "value" : "Retrato"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Potret"
+          }
         }
       }
     },
@@ -13136,6 +17978,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "posible impostor"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kemungkinan penipu"
           }
         },
         "nl" : {
@@ -13155,6 +18003,12 @@
             "value" : "Posible impostor"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kemungkinan penipu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13172,6 +18026,12 @@
             "value" : "correo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pos"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13187,6 +18047,12 @@
             "state" : "translated",
             "value" : "Publicar ${postText} en Nostr"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting ${postText} ke Nostr"
+          }
         }
       }
     },
@@ -13198,6 +18064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicar acciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting tindakan"
           }
         },
         "nl" : {
@@ -13217,6 +18089,12 @@
             "value" : "Contenido de la publicación: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten postingan: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13231,6 +18109,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Detalles de la publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detail posting"
           }
         },
         "nl" : {
@@ -13249,6 +18133,12 @@
             "value" : "Publicar GIF usando Blossom"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting GIF menggunakan Blossom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13263,6 +18153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicar nueva foto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting Foto Baru"
           }
         },
         "nl" : {
@@ -13283,6 +18179,12 @@
             "value" : "Vista previa de la publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratinjau postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13297,6 +18199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicar texto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting Teks"
           }
         }
       }
@@ -13314,6 +18222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Correo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pos"
           }
         },
         "nl" : {
@@ -13339,6 +18253,12 @@
             "value" : "Correo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pos"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13353,6 +18273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicado en %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diposting di %@"
           }
         },
         "nl" : {
@@ -13372,6 +18298,12 @@
             "value" : "Publicado vía %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diposting melalui %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13389,6 +18321,12 @@
             "value" : "Destino"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13403,6 +18341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicación y carga de medios"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting & Pengunggahan Media"
           }
         },
         "nl" : {
@@ -13422,6 +18366,12 @@
             "value" : "Publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13436,6 +18386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las publicaciones que contengan esto se filtrarán de tu feed."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan yang berisi ini akan disaring dari feed Anda"
           }
         },
         "nl" : {
@@ -13454,6 +18410,12 @@
             "value" : "Publicaciones de cualquier persona a las que reaccionaron las personas que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari siapa pun ditanggapi oleh orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13470,6 +18432,12 @@
             "value" : "Publicaciones de cualquier persona que más les gustan o que las personas que sigues vuelven a publicar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari siapa pun yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13484,6 +18452,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicaciones de cualquier persona que sean más zapped por las personas que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari siapa pun yang paling banyak zap dipedulikan oleh orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -13503,6 +18477,12 @@
             "value" : "Publicaciones de cualquier persona a las que las personas a las que sigues reaccionan con varios emojis específicos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari siapa pun yang ditanggapi dengan beberapa emoji tertentu oleh orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13520,6 +18500,12 @@
             "value" : "Publicaciones de contactos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13534,6 +18520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicaciones de personas seguidas por la cuenta [Explore Feed](nostur:p:afba415fa31944f579eaf8d291a1d76bc237a527a878e92d7e3b9fc669b14320)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari orang yang diikuti oleh akun [Jelajahi Umpan](nostur:p:afba415fa31944f579eaf8d291a1d76bc237a527a878e92d7e3b9fc669b14320)"
           }
         },
         "nl" : {
@@ -13553,6 +18545,12 @@
             "value" : "Publicaciones de personas que no sigues que les gustan más o que las personas que sigues vuelven a publicar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari orang yang tidak Anda ikuti yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13568,6 +18566,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicaciones de relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan dari relays"
           }
         },
         "nl" : {
@@ -13587,6 +18591,12 @@
             "value" : "Publicaciones que más les gustaron o volvieron a publicar las personas que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan yang paling disukai atau diposting ulang oleh orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13603,6 +18613,12 @@
             "value" : "prefijo: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "awalan: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13617,6 +18633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preparando vídeo..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mempersiapkan video..."
           }
         },
         "nl" : {
@@ -13636,6 +18658,12 @@
             "value" : "Avance"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratinjau"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13652,6 +18680,12 @@
             "state" : "translated",
             "value" : "Aplicación de vista previa"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratinjau Aplikasi"
+          }
         }
       }
     },
@@ -13661,6 +18695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anteriormente conocido como: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sebelumnya dikenal sebagai: %@"
           }
         },
         "nl" : {
@@ -13680,6 +18720,12 @@
             "value" : "privado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13697,6 +18743,12 @@
             "value" : "conversación privada"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percakapan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13711,6 +18763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "clave privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci pribadi"
           }
         },
         "nl" : {
@@ -13730,6 +18788,12 @@
             "value" : "Clave privada copiada al portapapeles"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci pribadi disalin ke papan klip"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13745,6 +18809,12 @@
             "state" : "translated",
             "value" : "La clave privada no está disponible para esta cuenta."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci pribadi tidak tersedia untuk akun ini."
+          }
         }
       }
     },
@@ -13755,6 +18825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "nota privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan pribadi"
           }
         },
         "nl" : {
@@ -13774,6 +18850,12 @@
             "value" : "notas privadas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13791,6 +18873,12 @@
             "value" : "Notas privadas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catatan Pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13806,6 +18894,12 @@
             "state" : "translated",
             "value" : "Se requiere respuesta privada (responder a una publicación privada)"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diperlukan balasan pribadi (membalas postingan pribadi)"
+          }
         }
       }
     },
@@ -13815,6 +18909,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Privado zap"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zap Pribadi"
           }
         },
         "nl" : {
@@ -13834,6 +18934,12 @@
             "value" : "Problema al analizar el URI de conexión NWC"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masalah saat mengurai URI koneksi NWC"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13849,6 +18955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blasfemia"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kata-kata kotor"
           }
         },
         "nl" : {
@@ -13868,6 +18980,12 @@
             "value" : "Perfil"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13883,6 +19001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL del banner del perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL spanduk profil"
           }
         },
         "nl" : {
@@ -13902,6 +19026,12 @@
             "value" : "Banners de perfil: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanduk profil: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13917,6 +19047,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL de la imagen de perfil"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL gambar profil"
           }
         },
         "nl" : {
@@ -13936,6 +19072,12 @@
             "value" : "Imágenes de perfil: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gambar profil: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13952,6 +19094,12 @@
             "value" : "clave pública: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kunci pub: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13963,6 +19111,12 @@
     "pubkeysByWriteRelays" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pubkeysByWriteRelays"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "pubkeysByWriteRelays"
@@ -13984,6 +19138,12 @@
             "value" : "Clave pública"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci publik"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13999,6 +19159,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Clave pública copiada al portapapeles"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci publik disalin ke papan klip"
           }
         },
         "nl" : {
@@ -14019,6 +19185,12 @@
             "value" : "Clave pública o privada (npub o nsec)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci publik atau pribadi (npub atau nsec)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14034,6 +19206,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menerbitkan"
           }
         },
         "nl" : {
@@ -14052,6 +19230,12 @@
             "value" : "Publicar lista ahora"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan daftar sekarang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14066,6 +19250,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publica en qué relays deseas recibir DM.\n\nEsto le permite utilizar un formato de mensajería más privado (NIP-17).\n\nOtras personas que no hayan actualizado aún pueden comunicarse con usted utilizando el formato anterior (NIP-04)."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan relays mana yang ingin Anda terima DM.\n\nHal ini memungkinkan Anda untuk menggunakan format pesan yang lebih pribadi (NIP-17).\n\nOrang lain yang belum melakukan upgrade masih dapat berkomunikasi dengan Anda menggunakan format lama (NIP-04)."
           }
         },
         "nl" : {
@@ -14084,6 +19274,12 @@
             "value" : "Publicar insignias seleccionadas en el perfil"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan lencana yang dipilih di profil"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14098,6 +19294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicar en relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ke relays"
           }
         },
         "nl" : {
@@ -14117,6 +19319,12 @@
             "value" : "Publicar en este relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ke relay ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14132,6 +19340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicado relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterbitkan relays"
           }
         },
         "nl" : {
@@ -14151,6 +19365,12 @@
             "value" : "Publicado relays para %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays yang diterbitkan untuk %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14165,6 +19385,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicado en:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterbitkan ke:"
           }
         },
         "nl" : {
@@ -14182,6 +19408,12 @@
             "state" : "translated",
             "value" : "Publica una nueva publicación en la red Nostr utilizando su cuenta activa."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan postingan baru ke jaringan Nostr menggunakan akun aktif Anda."
+          }
         }
       }
     },
@@ -14191,6 +19423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Púrpura"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungu"
           }
         },
         "nl" : {
@@ -14209,6 +19447,12 @@
             "state" : "translated",
             "value" : "El escaneo QR no está disponible en este dispositivo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pemindaian QR tidak tersedia di perangkat ini"
+          }
         }
       }
     },
@@ -14219,6 +19463,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cita"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengutip"
           }
         },
         "nl" : {
@@ -14239,6 +19489,12 @@
             "value" : "Publicación de cotización"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan kutipan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14253,6 +19509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cita..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengutip..."
           }
         },
         "nl" : {
@@ -14271,6 +19533,12 @@
             "value" : "levantar la mano"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angkat tangan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14286,6 +19554,12 @@
             "state" : "translated",
             "value" : "Reaccionar..."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bereaksi..."
+          }
         }
       }
     },
@@ -14295,6 +19569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Botones de reacción"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tombol reaksi"
           }
         },
         "nl" : {
@@ -14314,6 +19594,12 @@
             "value" : "reacciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reaksi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14329,6 +19615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reacciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reaksi"
           }
         },
         "nl" : {
@@ -14347,6 +19639,12 @@
             "value" : "Las reacciones a tus publicaciones aparecerán aquí"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reaksi terhadap postingan Anda akan muncul di sini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14361,6 +19659,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "leer"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "membaca"
           }
         },
         "nl" : {
@@ -14380,6 +19684,12 @@
             "value" : "leer + escribir"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "membaca + menulis"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14395,6 +19705,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Solo lectura"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hanya baca"
           }
         },
         "nl" : {
@@ -14414,6 +19730,12 @@
             "value" : "Modo de solo lectura"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode hanya baca"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14428,6 +19750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "leer: leíste este relay, por lo que otros deberían publicar allí."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "read: Anda membaca dari relay ini, jadi orang lain harus mempostingnya di sana."
           }
         },
         "nl" : {
@@ -14447,6 +19775,12 @@
             "value" : "Lee"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membaca"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14462,6 +19796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Razón"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alasan"
           }
         },
         "nl" : {
@@ -14482,6 +19822,12 @@
             "value" : "Retransmitir"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siaran ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14500,6 +19846,12 @@
             "value" : "Retransmisión (otra vez)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siaran ulang (lagi)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14514,6 +19866,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "REC"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REKAM"
           }
         },
         "nl" : {
@@ -14533,6 +19891,12 @@
             "value" : "Recibo de"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanda terima dari"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14550,6 +19914,12 @@
             "value" : "Recibir de este relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terima dari relay ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14564,6 +19934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reciba notificaciones cuando Nostur esté en segundo plano"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terima pemberitahuan saat Nostur ada di latar belakang"
           }
         },
         "nl" : {
@@ -14583,6 +19959,12 @@
             "value" : "Recibió"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterima"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14598,6 +19980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Recibido de:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diterima dari:"
           }
         },
         "nl" : {
@@ -14617,6 +20005,12 @@
             "value" : "Fijado recientemente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baru-baru ini disematkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14633,6 +20027,12 @@
             "value" : "Vuelva a comprobar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Periksa kembali"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14647,6 +20047,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Recomendado por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direkomendasikan oleh"
           }
         },
         "nl" : {
@@ -14666,6 +20072,12 @@
             "value" : "Reconfigurar anunciado relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasi ulang mengumumkan relays"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14680,6 +20092,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reconfigurar anunciado relays..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasi ulang relays yang diumumkan..."
           }
         },
         "nl" : {
@@ -14699,6 +20117,12 @@
             "value" : "Reconfigurar publicado relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasikan ulang relays yang diterbitkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14713,6 +20137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "grabar un vídeo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rekam video"
           }
         },
         "nl" : {
@@ -14732,6 +20162,12 @@
             "value" : "grabar audio"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rekam audio"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14746,6 +20182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grabar mensaje de voz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rekam Pesan Suara"
           }
         },
         "nl" : {
@@ -14764,6 +20206,12 @@
             "value" : "Grabaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rekaman"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14778,6 +20226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rojo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merah"
           }
         },
         "nl" : {
@@ -14797,6 +20251,12 @@
             "value" : "Canjear"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menukarkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14814,6 +20274,12 @@
             "value" : "Refrescar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyegarkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14825,6 +20291,12 @@
     "Relay" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relay"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Relay"
@@ -14846,6 +20318,12 @@
             "value" : "Piloto automático Relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relay Pilot Otomatis"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14860,6 +20338,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estadísticas de conexión Relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistik koneksi Relay"
           }
         },
         "nl" : {
@@ -14878,6 +20362,12 @@
             "value" : "Conexiones Relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi Relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14894,6 +20384,12 @@
             "value" : "Feed de Relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14908,6 +20404,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Información sobre Relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "informasi Relay"
           }
         },
         "nl" : {
@@ -14927,6 +20429,12 @@
             "value" : "Maestría Relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penguasaan Relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14942,6 +20450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selección Relay"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilihan Relay"
           }
         },
         "nl" : {
@@ -14961,6 +20475,12 @@
             "value" : "Configuración de Relay"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan Relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14978,6 +20498,12 @@
             "value" : "Relay estadísticas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistik Relay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14990,6 +20516,12 @@
       "comment" : "Relay URL header",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL Relay"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL Relay"
@@ -15012,6 +20544,12 @@
             "value" : "Relays"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15027,6 +20565,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Relays Nostur utiliza para buscar contenido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays Nostur digunakan untuk mencari konten"
           }
         },
         "nl" : {
@@ -15045,6 +20589,12 @@
             "value" : "Relays Nostur utiliza para buscar o publicar contenido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays Nostur digunakan untuk mencari atau mempublikasikan konten"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15059,6 +20609,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Relays que otros usarán para encontrar tu contenido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays yang akan digunakan orang lain untuk menemukan konten Anda"
           }
         },
         "nl" : {
@@ -15077,6 +20633,12 @@
             "value" : "Relays para recibir mensaje privado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays untuk menerima pesan pribadi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15091,6 +20653,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Relays en el que publicas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays tempat Anda memposting"
           }
         },
         "nl" : {
@@ -15109,6 +20677,12 @@
             "value" : "Relays leíste desde"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays tempat Anda membaca"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15120,6 +20694,12 @@
     "Relays:" : {
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relays:"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Relays:"
@@ -15142,6 +20722,12 @@
             "value" : "Recargar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muat ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15156,6 +20742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Recuerda alimentar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingat memberi makan"
           }
         },
         "nl" : {
@@ -15175,6 +20767,12 @@
             "value" : "Recuerda esta cantidad para todos los zaps"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingat jumlah ini untuk semua zaps"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15189,6 +20787,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¡Recordatorio configurado!"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set pengingat!"
           }
         },
         "nl" : {
@@ -15207,6 +20811,12 @@
             "value" : "El firmante remoto aparece sin conexión; la publicación se guardará pero no se publicará"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penanda tangan jarak jauh tampak offline, postingan akan disimpan tetapi tidak dipublikasikan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15221,6 +20831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eliminar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menghapus"
           }
         },
         "nl" : {
@@ -15239,6 +20855,12 @@
             "value" : "Eliminar contactos %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus kontak %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15253,6 +20875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quitar audio"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus audio"
           }
         },
         "nl" : {
@@ -15272,6 +20900,12 @@
             "value" : "Eliminar autor"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus penulis"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15288,6 +20922,12 @@
             "value" : "Quitar columna"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus kolom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15302,6 +20942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quitar del escenario"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus dari panggung"
           }
         },
         "nl" : {
@@ -15321,6 +20967,12 @@
             "value" : "Quitar etiqueta de impostor"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus label penipu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15335,6 +20987,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quitar moderador"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus moderator"
           }
         },
         "nl" : {
@@ -15353,6 +21011,12 @@
             "value" : "Eliminar este relay: %@?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus relay ini: %@?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15367,6 +21031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Repetición"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memutar ulang"
           }
         },
         "nl" : {
@@ -15386,6 +21056,12 @@
             "value" : "Respuestas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balasan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15400,6 +21076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las respuestas y menciones aparecerán aquí."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balasan dan sebutan akan muncul di sini"
           }
         },
         "nl" : {
@@ -15417,6 +21099,12 @@
             "state" : "translated",
             "value" : "Responder de forma anónima"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balas secara anonim"
+          }
         }
       }
     },
@@ -15426,6 +21114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Responder en privado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jawab secara pribadi"
           }
         },
         "nl" : {
@@ -15444,6 +21138,12 @@
             "value" : "Responder..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15460,6 +21160,12 @@
             "value" : "Respondiendo a"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15474,6 +21180,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Respondiendo a **%@**"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas **%@**"
           }
         },
         "nl" : {
@@ -15493,6 +21205,12 @@
             "value" : "Respondiendo a la gente %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas orang %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15508,6 +21226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Respondiendo a: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas ke: %@"
           }
         },
         "nl" : {
@@ -15527,6 +21251,12 @@
             "value" : "Respondiendo a: %@ y %lld otros"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas ke: %@ dan %lld lainnya"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15542,6 +21272,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Respondiendo a..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membalas..."
           }
         },
         "nl" : {
@@ -15561,6 +21297,12 @@
             "value" : "Denunciar %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporkan %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15576,6 +21318,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Informe para"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporkan untuk"
           }
         },
         "nl" : {
@@ -15595,6 +21343,12 @@
             "value" : "Información del informe"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informasi Laporan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15612,6 +21366,12 @@
             "value" : "Denunciar persona"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporkan orang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15627,6 +21387,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reportar publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporkan postingan"
           }
         },
         "nl" : {
@@ -15652,6 +21418,12 @@
             "value" : "Informe"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15669,6 +21441,12 @@
             "value" : "Volver a publicar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15683,6 +21461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vuelva a publicar o cite esta publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repost atau kutip postingan ini"
           }
         },
         "nl" : {
@@ -15702,6 +21486,12 @@
             "value" : "vuelto a publicar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mem-posting ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15716,6 +21506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicado nuevamente por"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diposting ulang oleh"
           }
         },
         "nl" : {
@@ -15735,6 +21531,12 @@
             "value" : "republicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "memposting ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15751,6 +21553,12 @@
             "value" : "Republicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repost"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15765,6 +21573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Las reenvíos de tus publicaciones aparecerán aquí."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repost postingan Anda akan muncul di sini"
           }
         },
         "nl" : {
@@ -15784,6 +21598,12 @@
             "value" : "Republicar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15798,6 +21618,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volver a publicar la publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ulang postingan"
           }
         },
         "nl" : {
@@ -15817,6 +21643,12 @@
             "value" : "Volver a publicar en"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ulang ke"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15832,6 +21664,12 @@
             "state" : "translated",
             "value" : "Volver a publicar en DM relays"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ulang ke DM relays"
+          }
         }
       }
     },
@@ -15841,6 +21679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volver a publicar en relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publikasikan ulang ke relays"
           }
         },
         "nl" : {
@@ -15858,6 +21702,12 @@
             "state" : "translated",
             "value" : "Latencia de respuesta REQ"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latensi respons REQ"
+          }
         }
       }
     },
@@ -15867,6 +21717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Solicitar eliminación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minta penghapusan"
           }
         },
         "nl" : {
@@ -15886,6 +21742,12 @@
             "value" : "Solicitudes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permintaan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15900,6 +21762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "requerido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "diperlukan"
           }
         },
         "nl" : {
@@ -15918,6 +21786,12 @@
             "value" : "Volver a escanear"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pindai ulang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15932,6 +21806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reiniciar sala"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulai ulang ruangan"
           }
         },
         "nl" : {
@@ -15950,6 +21830,12 @@
             "value" : "Restaurar contactos %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulihkan kontak %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15964,6 +21850,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restaurar la configuración anterior de NWC"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kembalikan konfigurasi NWC sebelumnya"
           }
         },
         "nl" : {
@@ -15981,6 +21873,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restringir la descarga automática de medios publicados por otros"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batasi pengunduhan otomatis media yang diposting oleh orang lain"
           }
         },
         "nl" : {
@@ -16001,6 +21899,12 @@
             "value" : "Restringir la descarga de medios"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batasi pengunduhan media"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16016,6 +21920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "restringido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "terbatas"
           }
         },
         "nl" : {
@@ -16034,6 +21944,12 @@
             "value" : "Reanudar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melanjutkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16048,6 +21964,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reanuda el feed desde donde lo dejaste cuando vuelvas a abrir la aplicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lanjutkan umpan dari bagian terakhir yang Anda tinggalkan saat Anda membuka kembali aplikasi"
           }
         },
         "nl" : {
@@ -16066,6 +21988,12 @@
             "value" : "Volver a tomar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merebut kembali"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16082,6 +22010,12 @@
             "value" : "Rever"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mencoba kembali"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16096,6 +22030,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reintentar con autenticación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba lagi dengan autentikasi"
           }
         },
         "nl" : {
@@ -16115,6 +22055,12 @@
             "value" : "Revelar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengungkap"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16129,6 +22075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Revelar clave privada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungkapkan kunci pribadi"
           }
         },
         "nl" : {
@@ -16146,6 +22098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "s"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S"
           }
         },
         "nl" : {
@@ -16169,6 +22127,12 @@
             "state" : "translated",
             "value" : "Muestras (5m/15m/1h): %1$lld/%2$lld/%3$lld"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sampel (5m/15m/1jam): %1$lld/%2$lld/%3$lld"
+          }
         }
       }
     },
@@ -16178,6 +22142,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "se sienta"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "duduk"
           }
         },
         "nl" : {
@@ -16198,6 +22168,12 @@
             "value" : "sábados"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16213,6 +22189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ahorrar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyimpan"
           }
         },
         "nl" : {
@@ -16231,6 +22213,12 @@
             "value" : "Guardar en archivo..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simpan ke berkas..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16245,6 +22233,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Guardar en la biblioteca de fotos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simpan ke Perpustakaan Foto"
           }
         },
         "nl" : {
@@ -16262,6 +22256,12 @@
             "state" : "translated",
             "value" : "Guardar en el selector"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simpan ke pemilih"
+          }
         }
       }
     },
@@ -16271,6 +22271,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Guardado en el selector"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disimpan ke pemilih"
           }
         }
       }
@@ -16283,6 +22289,12 @@
             "state" : "translated",
             "value" : "Escanear QR"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pindai QR"
+          }
         }
       }
     },
@@ -16294,6 +22306,12 @@
             "state" : "translated",
             "value" : "El código QR escaneado no es un URI válido de Nostr Wallet Connect"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kode QR yang dipindai bukan URI Nostr Wallet Connect yang valid"
+          }
         }
       }
     },
@@ -16304,6 +22322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Escaneando relays en busca de mensajes %lld/Hace 12 meses..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memindai relays untuk pesan %lld/12 bulan yang lalu..."
           }
         },
         "nl" : {
@@ -16322,6 +22346,12 @@
             "value" : "Escaneando relays en busca de mensajes %lld/Hace 36 meses..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memindai relays untuk pesan %lld/36 bulan yang lalu..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16336,6 +22366,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cronograma"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jadwal"
           }
         },
         "nl" : {
@@ -16356,6 +22392,12 @@
             "value" : "captura de pantalla"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tangkapan layar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16371,6 +22413,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mencari"
           }
         },
         "nl" : {
@@ -16391,6 +22439,12 @@
             "value" : "Buscar contacto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16406,6 +22460,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscar contactos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari kontak"
           }
         },
         "nl" : {
@@ -16425,6 +22485,12 @@
             "value" : "Buscar GIF"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari GIF"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16440,6 +22506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscar en marcadores..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari di bookmark..."
           }
         },
         "nl" : {
@@ -16459,6 +22531,12 @@
             "value" : "Buscar..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mencari..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16475,6 +22553,12 @@
             "state" : "translated",
             "value" : "segundoBuscando"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "keduaPengambilan"
+          }
         }
       }
     },
@@ -16485,6 +22569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vea lo que está pasando en nostr ahora mismo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat apa yang terjadi di nostr sekarang"
           }
         },
         "nl" : {
@@ -16504,6 +22594,12 @@
             "value" : "Seleccionar contactos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih kontak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16518,6 +22614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleccionar tipos de contenido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih tipe konten"
           }
         },
         "nl" : {
@@ -16536,6 +22638,12 @@
             "value" : "Seleccionar fecha y hora"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Tanggal & Waktu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16552,6 +22660,12 @@
             "value" : "Seleccione foto o video"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Foto atau Video"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16566,6 +22680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleccione relay(es)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih relay"
           }
         },
         "nl" : {
@@ -16585,6 +22705,12 @@
             "value" : "nsecBunker autohospedado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nsecBunker yang dihosting sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16599,6 +22725,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengirim"
           }
         },
         "nl" : {
@@ -16617,6 +22749,12 @@
             "value" : "Enviar %@ sats %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim %@ sats %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16633,6 +22771,12 @@
             "value" : "Enviar %@ sats a %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim %@ sats ke %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16647,6 +22791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviar de forma anónima"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim secara anonim"
           }
         },
         "nl" : {
@@ -16667,6 +22817,12 @@
             "value" : "Enviar DM a"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim DM ke"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16682,6 +22838,12 @@
             "state" : "translated",
             "value" : "Enviar publicación Nostr"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim Pos Nostr"
+          }
         }
       }
     },
@@ -16691,6 +22853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviar prueba de pago"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim tes pembayaran"
           }
         },
         "nl" : {
@@ -16707,6 +22875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviar foto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim Foto"
           }
         },
         "nl" : {
@@ -16726,6 +22900,12 @@
             "value" : "Enviar sats"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim sats"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16740,6 +22920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Envía sats a:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim sats ke:"
           }
         },
         "nl" : {
@@ -16759,6 +22945,12 @@
             "value" : "Enviar a: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim ke: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16774,6 +22966,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviando a: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengirim ke: %@"
           }
         },
         "nl" : {
@@ -16792,6 +22990,12 @@
             "state" : "translated",
             "value" : "Enviado %@ sats"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terkirim %@ sats"
+          }
         }
       }
     },
@@ -16809,6 +23013,12 @@
             "state" : "translated",
             "value" : "Enviado %1$@ sats en [publicación](nostur:e:%2$@)"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengirim %1$@ sats di [postingan](nostur:e:%2$@)"
+          }
         }
       }
     },
@@ -16819,6 +23029,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviado a %lld relays"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dikirim ke %lld relays"
           }
         },
         "nl" : {
@@ -16838,6 +23054,12 @@
             "value" : "Enviado a:"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dikirim ke:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16853,6 +23075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dirección del servidor"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alamat server"
           }
         },
         "nl" : {
@@ -16871,6 +23099,12 @@
             "value" : "Los servidores que se encuentren más arriba en la lista se utilizarán primero"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server yang lebih tinggi dalam daftar akan digunakan terlebih dahulu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16885,6 +23119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La sesión ha terminado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesi telah berakhir"
           }
         },
         "nl" : {
@@ -16903,6 +23143,12 @@
             "value" : "Establecer fecha/hora"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tetapkan tanggal/waktu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16917,6 +23163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Establecer recordatorio"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setel pengingat"
           }
         },
         "nl" : {
@@ -16936,6 +23188,12 @@
             "value" : "Ajustes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16953,6 +23211,12 @@
             "value" : "Ajustes..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16967,6 +23231,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compartir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membagikan"
           }
         },
         "nl" : {
@@ -16986,6 +23256,12 @@
             "value" : "Compartir destacado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan sorotan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17001,6 +23277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compartir enlace"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan tautan"
           }
         },
         "nl" : {
@@ -17020,6 +23302,12 @@
             "value" : "Compartir lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17034,6 +23322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compartir captura de pantalla"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan tangkapan layar"
           }
         },
         "nl" : {
@@ -17052,6 +23346,12 @@
             "value" : "Comparte esta lista con un título diferente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan daftar ini dengan judul berbeda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17067,6 +23367,12 @@
             "state" : "translated",
             "value" : "Compartir..."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membagikan..."
+          }
         }
       }
     },
@@ -17076,6 +23382,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Compartido desde **Nostur**"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dibagikan dari **Nostur**"
           }
         },
         "nl" : {
@@ -17094,6 +23406,12 @@
             "value" : "Vídeos cortos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video pendek"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17110,6 +23428,12 @@
             "value" : "Vídeos cortos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video Pendek"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17124,6 +23448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Videos cortos de personas que sigues"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan video pendek dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -17143,6 +23473,12 @@
             "value" : "Espectáculo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menunjukkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17158,6 +23494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar el feed de %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan umpan %@"
           }
         },
         "nl" : {
@@ -17176,6 +23518,12 @@
             "value" : "Mostrar las reacciones de %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunjukkan reaksi %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17190,6 +23538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar solicitudes ocultas de %lld (podría ser spam)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan permintaan tersembunyi %lld (bisa jadi spam)"
           }
         },
         "nl" : {
@@ -17209,6 +23563,12 @@
             "value" : "Mostrar de todos modos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tetap tunjukkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17225,6 +23585,12 @@
             "value" : "Mostrar bloqueado (%lld)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan diblokir (%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17239,6 +23605,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar marcadores"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan bookmark"
           }
         },
         "nl" : {
@@ -17258,6 +23630,12 @@
             "value" : "Mostrar relays adicional usado en la vista previa de la publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan relays tambahan yang digunakan pada pratinjau posting"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17275,6 +23653,12 @@
             "value" : "Mostrar feed"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan umpan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17289,6 +23673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar feed en el selector de feeds"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan feed di pemilih feed"
           }
         },
         "nl" : {
@@ -17308,6 +23698,12 @@
             "value" : "Mostrar feed en la barra de pestañas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan umpan di bilah tab"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17323,6 +23719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar valor fiduciario"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunjukkan nilai fiat"
           }
         },
         "nl" : {
@@ -17342,6 +23744,12 @@
             "value" : "Mostrar desde qué aplicación alguien publicó"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunjukkan dari aplikasi mana seseorang memposting"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17357,6 +23765,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar banner en vivo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan spanduk Langsung"
           }
         },
         "nl" : {
@@ -17376,6 +23790,12 @@
             "value" : "Mostrar el valor fiat local junto a sats en la publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan nilai fiat lokal di sebelah sats pada postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17391,6 +23811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar el valor fiduciario local junto a los sats en las publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan nilai fiat lokal di sebelah sats pada postingan"
           }
         },
         "nl" : {
@@ -17409,6 +23835,12 @@
             "value" : "Mostrar más"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan lebih banyak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17423,6 +23855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar más (%lld)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan lebih banyak (%lld)"
           }
         },
         "nl" : {
@@ -17440,6 +23878,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar más..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan lebih banyak..."
           }
         },
         "nl" : {
@@ -17460,6 +23904,12 @@
             "value" : "Mostrar estadísticas de publicaciones en la línea de tiempo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan statistik postingan di timeline"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17474,6 +23924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar vista previa"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan pratinjau"
           }
         },
         "nl" : {
@@ -17492,6 +23948,12 @@
             "value" : "Mostrar vista previa de esta publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan Pratinjau postingan ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17508,6 +23970,12 @@
             "value" : "Mostrar respuestas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan balasan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17522,6 +23990,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar insignia de recuento no leído"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan lencana hitungan yang belum dibaca"
           }
         },
         "nl" : {
@@ -17542,6 +24016,12 @@
             "value" : "Mostrar el valor en USD junto a los sats en la publicación"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan nilai USD di sebelah sats pada postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17558,6 +24038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar el valor en USD junto a los sats en las publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan nilai USD di sebelah sats pada postingan"
           }
         },
         "nl" : {
@@ -17577,6 +24063,12 @@
             "value" : "Mostrar saldo de billetera"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan saldo dompet"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17592,6 +24084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar valor fiduciario zaps"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan nilai fiat zaps"
           }
         },
         "nl" : {
@@ -17610,6 +24108,12 @@
             "value" : "Se muestra en la barra de pestañas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditampilkan di bilah tab"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17624,6 +24128,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se muestra en la barra de pestañas (no pública)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditampilkan di bilah tab (bukan publik)"
           }
         },
         "nl" : {
@@ -17643,6 +24153,12 @@
             "value" : "Muestra el título 'Compartido desde Nostur' al compartir capturas de pantalla de publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menampilkan keterangan 'Dibagikan dari Nostur' saat membagikan tangkapan layar kiriman"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17658,6 +24174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Muestra cuando se están procesando artículos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menunjukkan kapan barang sedang diproses"
           }
         },
         "nl" : {
@@ -17677,6 +24199,12 @@
             "value" : "Firma cualquier evento nostr"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanda tangani acara nostr apa pun"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17694,6 +24222,12 @@
             "value" : "evento de firma"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanda tangani acara"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17708,6 +24242,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "evento_signo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tanda_acara"
           }
         },
         "nl" : {
@@ -17727,6 +24267,12 @@
             "value" : "Firmante"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penandatangan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17741,6 +24287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Firmando como"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menandatangani sebagai"
           }
         },
         "nl" : {
@@ -17760,6 +24312,12 @@
             "value" : "Saltar y probar primero como invitado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lewati dan coba sebagai tamu terlebih dahulu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17774,6 +24332,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algunos relays pueden requerir autenticación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beberapa relays mungkin memerlukan otentikasi"
           }
         },
         "nl" : {
@@ -17793,6 +24357,12 @@
             "state" : "translated",
             "value" : "La alimentación de alguien"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Seseorang"
+          }
         }
       }
     },
@@ -17803,6 +24373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "algo sobre ti"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesuatu tentang dirimu"
           }
         },
         "nl" : {
@@ -17822,6 +24398,12 @@
             "value" : "Algo sobre ti (biografía)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesuatu tentang dirimu (bio)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17838,6 +24420,12 @@
             "value" : "algo salió mal"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ada yang tidak beres"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17852,6 +24440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lo siento, se suponía que esto no debía suceder."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maaf, ini tidak seharusnya terjadi."
           }
         },
         "nl" : {
@@ -17872,6 +24466,12 @@
             "value" : "fuente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sumber"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17887,6 +24487,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Correo basura"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spam"
           }
         },
         "nl" : {
@@ -17905,6 +24511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtro de spam"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penyaring spam"
           }
         },
         "nl" : {
@@ -17929,6 +24541,12 @@
             "value" : "Spam filtrado en los últimos %1$@: artículos %2$lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spam difilter di item %1$@: %2$lld terakhir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17946,6 +24564,12 @@
             "value" : "Filtrado de spam"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penyaringan spam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17960,6 +24584,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtrado de spam"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penyaringan Spam"
           }
         },
         "nl" : {
@@ -17979,6 +24609,12 @@
             "value" : "Vocero"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pembicara"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17994,6 +24630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Palabra u oración específica"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kata atau kalimat tertentu"
           }
         },
         "nl" : {
@@ -18012,6 +24654,12 @@
             "value" : "Empezar a escuchar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulailah mendengarkan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18026,6 +24674,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Iniciar nido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulai Sarang"
           }
         },
         "nl" : {
@@ -18044,6 +24698,12 @@
             "value" : "Iniciar Nest (sala de audio)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulai Nest (Ruang Audio)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18058,6 +24718,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Empezar ahora"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulai sekarang"
           }
         },
         "nl" : {
@@ -18076,6 +24742,12 @@
             "value" : "Empezar a grabar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mulai merekam"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18092,6 +24764,12 @@
             "state" : "translated",
             "value" : "Iniciando cámara…"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memulai kamera…"
+          }
         }
       }
     },
@@ -18102,6 +24780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         },
         "nl" : {
@@ -18120,6 +24804,12 @@
             "state" : "translated",
             "value" : "Arroyo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sungai kecil"
+          }
         }
       }
     },
@@ -18129,6 +24819,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La transmisión ha terminado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streaming telah berakhir"
           }
         },
         "nl" : {
@@ -18147,6 +24843,12 @@
             "state" : "translated",
             "value" : "transmisión"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mengalir"
+          }
         }
       }
     },
@@ -18157,6 +24859,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suscribir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berlangganan"
           }
         },
         "nl" : {
@@ -18175,6 +24883,12 @@
             "value" : "Suscríbete para recibir actualizaciones de la lista"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berlangganan pembaruan daftar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18189,6 +24903,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apoye a las personas que seleccionan listas de alta calidad enviándoles zapping"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dukung orang-orang yang menyusun daftar berkualitas tinggi dengan zapping mereka"
           }
         },
         "nl" : {
@@ -18209,6 +24929,12 @@
             "value" : "Desliza para desbloquear/activar silencio"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesek untuk membuka blokir/mengaktifkan suara"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18224,6 +24950,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cambie a un formato de DM más privado (NIP-17)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beralih ke format DM yang lebih pribadi (NIP-17)"
           }
         },
         "nl" : {
@@ -18242,6 +24974,12 @@
             "value" : "Cambie a un formato DM más privado (NIP-17) para mensajes nuevos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beralih ke format DM yang lebih pribadi (NIP-17) untuk pesan baru"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18258,6 +24996,12 @@
             "state" : "translated",
             "value" : "Pestaña"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab"
+          }
         }
       }
     },
@@ -18268,6 +25012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pestaña 1"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab 1"
           }
         }
       }
@@ -18280,6 +25030,12 @@
             "state" : "translated",
             "value" : "Pestaña 2"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab 2"
+          }
         }
       }
     },
@@ -18290,6 +25046,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pestaña 3"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab 3"
           }
         }
       }
@@ -18302,6 +25064,12 @@
             "state" : "translated",
             "value" : "Pestaña 4"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab 4"
+          }
         }
       }
     },
@@ -18313,6 +25081,12 @@
             "state" : "translated",
             "value" : "Pestaña 5"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tab 5"
+          }
         }
       }
     },
@@ -18323,6 +25097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Título de la pestaña"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Judul tab"
           }
         },
         "nl" : {
@@ -18341,6 +25121,12 @@
             "value" : "tomar una foto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambil foto"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18355,6 +25141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "tomar foto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambil Foto"
           }
         },
         "nl" : {
@@ -18373,6 +25165,12 @@
             "value" : "Toca la cuenta para excluirla"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk akun untuk dikecualikan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18387,6 +25185,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toca el micrófono para grabar un mensaje de voz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk mikrofon untuk merekam pesan suara"
           }
         },
         "nl" : {
@@ -18405,6 +25209,12 @@
             "value" : "Toque la campana de notificación cuando vea el perfil de alguien para recibir una notificación cuando publique."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk lonceng notifikasi saat melihat profil seseorang untuk menerima notifikasi saat mereka memposting."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18419,6 +25229,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toca para editar..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk untuk mengedit..."
           }
         },
         "nl" : {
@@ -18436,6 +25252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toca para cargar medios"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk untuk memuat media"
           }
         },
         "nl" : {
@@ -18456,6 +25278,12 @@
             "value" : "Toca para cargar vídeo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk untuk memuat video"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18470,6 +25298,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toca para alternar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk untuk beralih"
           }
         },
         "nl" : {
@@ -18488,6 +25322,12 @@
             "value" : "Términos y condiciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "syarat dan Ketentuan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18502,6 +25342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Términos de servicio"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketentuan Layanan"
           }
         },
         "nl" : {
@@ -18519,6 +25365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "prueba"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tes"
           }
         },
         "nl" : {
@@ -18539,6 +25391,12 @@
             "value" : "Prueba"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18557,6 +25415,12 @@
             "value" : "Alternar prueba"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uji Beralih"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18571,6 +25435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Publicación de texto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting Teks"
           }
         },
         "nl" : {
@@ -18588,6 +25458,12 @@
             "state" : "translated",
             "value" : "La cuenta desde la que publicar. El valor predeterminado es la cuenta actualmente activa si no se especifica."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun asal postingan. Defaultnya adalah akun yang aktif saat ini jika tidak ditentukan."
+          }
         }
       }
     },
@@ -18598,6 +25474,12 @@
             "state" : "translated",
             "value" : "La cuenta activa no puede publicar (puede ser una cuenta de solo lectura o de firmante remoto)."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun yang aktif tidak dapat memposting (mungkin akun hanya baca atau akun penanda tangan jarak jauh)."
+          }
         }
       }
     },
@@ -18607,6 +25489,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El feed de artículos muestra artículos de las personas que sigues en el período de tiempo seleccionado."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan artikel menampilkan artikel dari orang yang Anda ikuti dalam jangka waktu yang dipilih"
           }
         },
         "nl" : {
@@ -18625,6 +25513,12 @@
             "value" : "No se pudo cargar la base de datos."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basis data tidak dapat dimuat."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18639,6 +25533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El feed Discover muestra publicaciones de personas a las que no sigues que les gustan más o que las personas que sigues vuelven a publicar en las últimas horas %lld"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Temukan menunjukkan postingan dari orang yang tidak Anda ikuti yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti dalam %lld jam terakhir"
           }
         },
         "nl" : {
@@ -18657,6 +25557,12 @@
             "value" : "El feed de Emoji muestra publicaciones de cualquier persona a las que las personas que sigues reaccionan con emojis específicos en las últimas horas %lld."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Emoji menunjukkan kiriman dari siapa pun yang ditanggapi dengan emoji tertentu oleh orang yang Anda ikuti dalam %lld jam terakhir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18671,6 +25577,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El feed de la Galería muestra las imágenes que más les gustaron o que las personas que sigues han vuelto a publicar en las últimas horas %lld."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Galeri menampilkan gambar yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti dalam beberapa jam %lld terakhir"
           }
         },
         "nl" : {
@@ -18691,6 +25603,12 @@
             "value" : "La cuenta de invitado ya sigue a algunas personas. Puede leer publicaciones y ver perfiles, pero no puede publicar ni darle me gusta a cosas hasta que cree una nueva cuenta usted mismo."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun tamu sudah mengikuti beberapa orang. Anda dapat membaca postingan dan melihat profil, tetapi Anda tidak dapat memposting atau menyukai sesuatu sampai Anda membuat akun baru sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18708,6 +25626,12 @@
             "value" : "La cuenta de invitado ya sigue a algunas personas. Puede leer publicaciones y ver perfiles, pero no puede publicar ni reaccionar ante nada hasta que cree una nueva cuenta usted mismo."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun tamu sudah mengikuti beberapa orang. Anda dapat membaca postingan dan melihat profil, tetapi Anda tidak dapat memposting atau bereaksi terhadap apa pun sampai Anda membuat akun baru sendiri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18722,6 +25646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El feed Hot muestra las publicaciones de cualquier persona que hayan recibido más me gusta o que hayan vuelto a publicar las personas que sigues en las últimas horas %lld."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Panas menampilkan kiriman dari siapa pun yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti dalam %lld jam terakhir"
           }
         },
         "nl" : {
@@ -18741,6 +25671,12 @@
             "value" : "El feed Hot muestra las publicaciones que más les gustaron o que las personas que sigues han vuelto a publicar en las últimas horas %lld."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Panas menampilkan kiriman yang paling disukai atau diposkan ulang oleh orang yang Anda ikuti dalam beberapa jam %lld terakhir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18755,6 +25691,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se descubrió que el perfil anterior es similar al siguiente que ya estás siguiendo:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil di atas ternyata mirip dengan profil di bawah ini yang sudah Anda ikuti:"
           }
         },
         "nl" : {
@@ -18772,6 +25714,12 @@
             "state" : "translated",
             "value" : "No se pudo encontrar la cuenta seleccionada. Es posible que lo hayan eliminado."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akun yang dipilih tidak dapat ditemukan. Itu mungkin telah dihapus."
+          }
         }
       }
     },
@@ -18782,6 +25730,12 @@
             "state" : "translated",
             "value" : "El contenido del texto de la publicación a publicar."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konten teks postingan yang akan dipublikasikan."
+          }
         }
       }
     },
@@ -18791,6 +25745,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El feed de Zapped muestra las publicaciones de cualquier persona que hayan recibido más zapped de las personas que sigues en las últimas horas de %lld."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Zapped menampilkan postingan dari siapa saja yang paling banyak zapped oleh orang yang Anda ikuti dalam %lld jam terakhir"
           }
         },
         "nl" : {
@@ -18809,6 +25769,12 @@
             "value" : "Hay nuevas comunidades %lld"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ada komunitas baru %lld"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18823,6 +25789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hay 2 soluciones:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ada 2 solusi:"
           }
         },
         "nl" : {
@@ -18842,6 +25814,12 @@
             "value" : "Hubo un problema, no se pudo enviar sats."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ada masalah, tidak bisa mengirim sats"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18857,6 +25835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estos relays se utilizan para todas las cuentas y no se anuncian a menos que se configuren en la configuración específica de la cuenta."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays ini digunakan untuk semua akun, dan tidak diumumkan kecuali dikonfigurasi pada pengaturan khusus akun."
           }
         },
         "nl" : {
@@ -18876,6 +25860,12 @@
             "value" : "Estos relays se utilizan para todas las cuentas y no se publican a menos que se configuren en las pestañas específicas de la cuenta."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays ini digunakan untuk semua akun, dan tidak dipublikasikan kecuali dikonfigurasi pada tab khusus akun."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18892,6 +25882,12 @@
             "value" : "Estos relays se utilizan para todas sus cuentas y no se anuncian a menos que se configuren en las pestañas específicas de la cuenta."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays ini digunakan untuk semua akun Anda, dan tidak diumumkan kecuali dikonfigurasi pada tab khusus akun."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18906,6 +25902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estos pasos le ayudarán a que otros sepan en qué relays pueden encontrar las publicaciones de %@ y qué relays deberían usar otros para llegar a %@."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langkah-langkah ini membantu Anda memberi tahu orang lain di relays mana mereka dapat menemukan postingan %@ dan relays mana yang harus digunakan orang lain untuk mencapai %@."
           }
         },
         "nl" : {
@@ -18925,6 +25927,12 @@
             "value" : "Este artículo ha sido actualizado."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artikel ini telah diperbarui"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18939,6 +25947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esto puede deberse a que el receptor cambia a una dirección de rayos diferente."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hal ini dapat disebabkan oleh peralihan penerima ke alamat petir yang berbeda"
           }
         },
         "nl" : {
@@ -18958,6 +25972,12 @@
             "value" : "Esto proporciona más espacio en la pantalla al desplazarse."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini memberi lebih banyak ruang layar saat menggulir"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18972,6 +25992,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esta lista es pública."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar ini bersifat publik"
           }
         },
         "nl" : {
@@ -18991,6 +26017,12 @@
             "value" : "Esta conexión NWC no admite pagos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koneksi NWC ini tidak mendukung pembayaran"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19006,6 +26038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esta publicación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "posting ini"
           }
         },
         "nl" : {
@@ -19025,6 +26063,12 @@
             "value" : "Esta publicación y usuario"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting & pengguna ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19040,6 +26084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esta publicación tiene %lld más artículos."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Posting ini memiliki item %lld lebih banyak"
           }
         },
         "nl" : {
@@ -19059,6 +26109,12 @@
             "value" : "Esta publicación tiene 1 elemento más."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postingan ini memiliki 1 item lagi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19074,6 +26130,12 @@
             "state" : "translated",
             "value" : "Esta respuesta se publica desde una nueva identidad única que no está vinculada a ninguna de sus cuentas. Es desechable: no puedes editarlo, eliminarlo, deshacerlo ni responder nuevamente con esta identidad. Relays aún puede ver su dirección IP y su estilo de escritura puede identificarlo."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balasan ini dikirim dari identitas baru yang tidak tertaut ke akun Anda. Ini hanya sekali pakai — Anda tidak dapat mengedit, menghapus, membatalkan, atau membalas lagi dengan identitas ini. Relays masih dapat melihat alamat IP Anda, dan gaya penulisan Anda mungkin mengidentifikasi Anda."
+          }
         }
       }
     },
@@ -19084,6 +26146,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Esto **eliminará** tu:\n - Cuenta de Nostur\n - Clave privada (nsec) de Apple Keychain"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini akan **menghapus**:\n - Akun dari Nostur\n - Kunci pribadi (nsec) dari Apple Keychain"
           }
         },
         "nl" : {
@@ -19103,6 +26171,12 @@
             "value" : "Esto aparecerá en la parte superior de tu perfil y reemplazará cualquier publicación previamente fijada."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini akan muncul di bagian atas profil Anda dan menggantikan postingan yang dipasangi pin sebelumnya."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19120,6 +26194,12 @@
             "value" : "Hilo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19135,6 +26215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL en miniatura (256x256)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL gambar kecil (256x256)"
           }
         },
         "nl" : {
@@ -19160,6 +26246,12 @@
             "value" : "Bajo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendah"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19178,6 +26270,12 @@
           }
         },
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Normal"
@@ -19206,6 +26304,12 @@
             "value" : "Apagado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mati"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19220,6 +26324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Periodo de tiempo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu"
           }
         },
         "nl" : {
@@ -19238,6 +26348,12 @@
             "value" : "Se acabó el tiempo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19252,6 +26368,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se acabó el tiempo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis"
           }
         },
         "nl" : {
@@ -19270,6 +26392,12 @@
             "value" : "Tiempo de espera mientras se carga el feed de descubrimiento"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat feed penemuan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19284,6 +26412,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiempo de espera mientras se carga el feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat feed"
           }
         },
         "nl" : {
@@ -19302,6 +26436,12 @@
             "value" : "Tiempo de espera mientras se carga la galería"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat galeri"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19316,6 +26456,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiempo de espera mientras se carga alimentación caliente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat umpan panas"
           }
         },
         "nl" : {
@@ -19333,6 +26479,12 @@
             "state" : "translated",
             "value" : "Tiempo de espera mientras se carga la transmisión de transmisiones en vivo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat feed Live Stream"
+          }
         }
       }
     },
@@ -19342,6 +26494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiempo de espera al cargar publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waktu habis saat memuat postingan"
           }
         },
         "nl" : {
@@ -19360,6 +26518,12 @@
             "state" : "translated",
             "value" : "se acabó el tiempo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "batas waktu"
+          }
         }
       }
     },
@@ -19369,6 +26533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Consejo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tip"
           }
         },
         "nl" : {
@@ -19385,6 +26555,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Consejos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiat"
           }
         },
         "nl" : {
@@ -19404,6 +26580,12 @@
             "value" : "Título"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Judul"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19419,6 +26601,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Título de tu feed"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Judul feed Anda"
           }
         },
         "nl" : {
@@ -19437,6 +26625,12 @@
             "value" : "Para iniciar sesión con otras cuentas, pero seguir filtrando usando la cuenta principal Web of Trust"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Untuk login dengan akun lain, namun tetap memfilter menggunakan akun utama Web of Trust"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19451,6 +26645,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Para: %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kepada: %@"
           }
         },
         "nl" : {
@@ -19469,6 +26669,12 @@
             "state" : "translated",
             "value" : "TODO SENCILLO"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TODO PLAINTEKSTON"
+          }
         }
       }
     },
@@ -19478,6 +26684,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alternar filtros..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alihkan filter..."
           }
         },
         "nl" : {
@@ -19496,6 +26708,12 @@
             "value" : "alternar rojo"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "beralih menjadi merah"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19512,6 +26730,12 @@
             "state" : "translated",
             "value" : "Antorcha apagada"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obor Mati"
+          }
         }
       }
     },
@@ -19523,6 +26747,12 @@
             "state" : "translated",
             "value" : "Antorcha encendida"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senter Menyala"
+          }
         }
       }
     },
@@ -19532,6 +26762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Total: %lld"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah: %lld"
           }
         },
         "nl" : {
@@ -19548,6 +26784,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Recortar vídeo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Potong Video"
           }
         },
         "nl" : {
@@ -19567,6 +26809,12 @@
             "value" : "Intentar otra vez"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba lagi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19582,6 +26830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prueba la cuenta de invitado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba akun tamu"
           }
         },
         "nl" : {
@@ -19601,6 +26855,12 @@
             "value" : "Prueba Nostur como invitado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba Nostur sebagai tamu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19617,6 +26877,12 @@
             "state" : "translated",
             "value" : "Intenta buscar"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cobalah untuk mengambil"
+          }
         }
       }
     },
@@ -19626,6 +26892,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intenta usarlo de todos modos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cobalah untuk tetap menggunakannya"
           }
         },
         "nl" : {
@@ -19642,6 +26914,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Probando más relays..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mencoba lebih banyak relays..."
           }
         },
         "nl" : {
@@ -19661,6 +26939,12 @@
             "value" : "Apágalo para ahorrar batería y confía en el relays para la autenticidad de los mensajes."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Matikan untuk menghemat masa pakai baterai dan percayakan relays untuk keaslian pesan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19677,6 +26961,12 @@
             "state" : "translated",
             "value" : "Tipo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jenis"
+          }
         }
       }
     },
@@ -19687,6 +26977,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Escribe tu mensaje..."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketik pesan Anda..."
           }
         },
         "nl" : {
@@ -19706,6 +27002,12 @@
             "value" : "No se puede decodificar el token Cashu"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat memecahkan kode token Cashu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19721,6 +27023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se puede decodificar la factura del rayo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat memecahkan kode faktur kilat"
           }
         },
         "nl" : {
@@ -19739,6 +27047,12 @@
             "value" : "No se puede recuperar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19753,6 +27067,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se pueden recuperar contactos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil kontak"
           }
         },
         "nl" : {
@@ -19771,6 +27091,12 @@
             "value" : "No se puede recuperar el contenido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil konten"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19785,6 +27111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se puede recuperar el contenido:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil konten:"
           }
         },
         "nl" : {
@@ -19803,6 +27135,12 @@
             "value" : "No se pueden recuperar publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19819,6 +27157,12 @@
             "value" : "No se puede recuperar el perfil"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat mengambil profil"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19833,6 +27177,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se puede cargar la conversación"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat memuat percakapan"
           }
         },
         "nl" : {
@@ -19852,6 +27202,12 @@
             "value" : "No se puede cargar la transmisión"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat memuat streaming"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19867,6 +27223,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indisponible"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak tersedia"
           }
         },
         "nl" : {
@@ -19885,6 +27247,12 @@
             "value" : "No disponible: falta accountPubkey"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak tersedia: akunPubkey hilang"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19899,6 +27267,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desatascar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka blokir"
           }
         },
         "nl" : {
@@ -19917,6 +27291,12 @@
             "state" : "translated",
             "value" : "Desenfrenado"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dicentang"
+          }
         }
       }
     },
@@ -19928,6 +27308,12 @@
             "state" : "translated",
             "value" : "desconfigurado"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "belum dikonfigurasi"
+          }
         }
       }
     },
@@ -19937,6 +27323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desconfigurado"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dikonfigurasi"
           }
         },
         "nl" : {
@@ -19956,6 +27348,12 @@
             "value" : "Recuperar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batalkan penghapusan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19972,6 +27370,12 @@
             "value" : "Deshacer"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membuka"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19986,6 +27390,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dejar de seguir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berhenti mengikuti"
           }
         },
         "nl" : {
@@ -20005,6 +27415,12 @@
             "value" : "Dejar de seguir %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berhenti mengikuti %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20019,6 +27435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perlihatkan"
           }
         },
         "nl" : {
@@ -20038,6 +27460,12 @@
             "value" : "Dejar de silenciar"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membunyikan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20053,6 +27481,12 @@
             "state" : "translated",
             "value" : "Dejar silenciar vídeo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suarakan video"
+          }
         }
       }
     },
@@ -20062,6 +27496,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desprender"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Membuka peniti"
           }
         },
         "nl" : {
@@ -20081,6 +27521,12 @@
             "value" : "Desanclar de tu perfil"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lepas sematan dari profil Anda"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20096,6 +27542,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Evento no firmado o no válido"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acara yang tidak ditandatangani atau tidak valid"
           }
         },
         "nl" : {
@@ -20115,6 +27567,12 @@
             "value" : "zaps no verificado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zaps tidak terverifikasi"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20130,6 +27588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actualizar"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memperbarui"
           }
         },
         "nl" : {
@@ -20148,6 +27612,12 @@
             "value" : "Las actualizaciones se refieren a personas agregadas o eliminadas de esta lista, no a publicaciones o contenido."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pembaruan mengacu pada orang yang ditambahkan atau dihapus dari daftar ini, bukan postingan atau konten."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20162,6 +27632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actualiza tus DM"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tingkatkan DM Anda"
           }
         },
         "nl" : {
@@ -20181,6 +27657,12 @@
             "value" : "Actualice sus DM publicando en qué relays desea recibir DM.\n\nEsto le permite utilizar un formato de mensajería más privado (NIP-17).\n\nOtras personas que no hayan actualizado aún pueden comunicarse con usted utilizando el formato anterior (NIP-04)."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tingkatkan DM Anda dengan memublikasikan relays mana yang ingin Anda terima DM.\n\nHal ini memungkinkan Anda untuk menggunakan format pesan yang lebih pribadi (NIP-17).\n\nOrang lain yang belum melakukan upgrade masih dapat berkomunikasi dengan Anda menggunakan format lama (NIP-04)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20196,6 +27678,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Método de carga"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metode unggah"
           }
         },
         "nl" : {
@@ -20214,6 +27702,12 @@
             "value" : "Subiendo al servidor(es) Blossom..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengunggah ke server Blossom..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20228,6 +27722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Utilice relays adicional de los contactos en este feed para buscar publicaciones"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan relays tambahan dari kontak di feed ini untuk mengambil postingan"
           }
         },
         "nl" : {
@@ -20247,6 +27747,12 @@
             "value" : "Usar cuenta existente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan akun yang ada"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20261,6 +27767,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "usar foto"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan foto"
           }
         },
         "nl" : {
@@ -20280,6 +27792,12 @@
             "value" : "Utilice relay para buscar publicaciones"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan relay untuk mencari postingan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20294,6 +27812,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Usar vídeo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan Video"
           }
         },
         "nl" : {
@@ -20312,6 +27836,12 @@
             "state" : "translated",
             "value" : "El usuario no tiene configurada una dirección Lightning"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengguna belum menetapkan alamat kilat"
+          }
         }
       }
     },
@@ -20323,6 +27853,12 @@
             "state" : "translated",
             "value" : "La billetera de los usuarios no es compatible con nostr"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dompet pengguna tidak mendukung nostr"
+          }
         }
       }
     },
@@ -20333,6 +27869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Utiliza iCloud para sincronizar entre dispositivos"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menggunakan iCloud untuk menyinkronkan antar perangkat"
           }
         },
         "nl" : {
@@ -20351,6 +27893,12 @@
             "value" : "Usando cuenta: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menggunakan akun: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20367,6 +27915,12 @@
             "value" : "Usando NIP-04"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menggunakan NIP-04"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20381,6 +27935,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verificar nuevamente"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifikasi lagi"
           }
         },
         "nl" : {
@@ -20400,6 +27960,12 @@
             "value" : "Verificar firmas de mensajes"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifikasi tanda tangan pesan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20416,6 +27982,12 @@
             "state" : "translated",
             "value" : "Verificando..."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memverifikasi..."
+          }
         }
       }
     },
@@ -20427,6 +27999,12 @@
             "state" : "translated",
             "value" : "Verificando... Hecho."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memverifikasi... Selesai."
+          }
         }
       }
     },
@@ -20436,6 +28014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vídeo listo"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Videonya sudah siap"
           }
         },
         "nl" : {
@@ -20454,6 +28038,12 @@
             "value" : "Vídeos"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20468,6 +28058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ver en la web"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat di web"
           }
         },
         "nl" : {
@@ -20486,6 +28082,12 @@
             "state" : "translated",
             "value" : "verEstado: %@"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kondisi tampilan: %@"
+          }
         }
       }
     },
@@ -20495,6 +28097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suara"
           }
         },
         "nl" : {
@@ -20513,6 +28121,12 @@
             "value" : "Configuración de la fuente de mensajes de voz"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan umpan Pesan Suara"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20527,6 +28141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mensajes de voz"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan Suara"
           }
         },
         "nl" : {
@@ -20545,6 +28165,12 @@
             "value" : "Mensajes de voz (Yaks)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesan Suara (Yak)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20561,6 +28187,12 @@
             "value" : "Los mensajes de voz provienen de las personas que sigues"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umpan Pesan Suara dari orang yang Anda ikuti"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20575,6 +28207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "VPN detectada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VPN terdeteksi"
           }
         },
         "nl" : {
@@ -20594,6 +28232,12 @@
             "value" : "Detección de VPN"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deteksi VPN"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20608,6 +28252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "VPN no detectada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VPN tidak terdeteksi"
           }
         },
         "nl" : {
@@ -20627,6 +28277,12 @@
             "value" : "No necesitamos insignias apestosas"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kami Tidak Membutuhkan Lencana yang Tidak Bau"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20641,6 +28297,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aplicación web"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplikasi Web"
           }
         },
         "nl" : {
@@ -20660,6 +28322,12 @@
             "value" : "Filtro Web of Trust"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "penyaring Web of Trust"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20677,6 +28345,12 @@
             "value" : "Filtro de spam Web of Trust"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter spam Web of Trust"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20691,6 +28365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Semana"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pekan"
           }
         },
         "nl" : {
@@ -20710,6 +28390,12 @@
             "value" : "Bienvenido a **Nostur**"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selamat datang di **Nostur**"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20724,6 +28410,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bienvenido a la charla"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selamat datang di obrolan"
           }
         },
         "nl" : {
@@ -20743,6 +28435,12 @@
             "value" : "Qué"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20758,6 +28456,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¿De qué quieres hablar?"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa yang ingin kamu bicarakan?"
           }
         },
         "nl" : {
@@ -20777,6 +28481,12 @@
             "value" : "¿Lo que está sucediendo?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa yang terjadi?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20792,6 +28502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cuando esté en la parte superior, desplacese automáticamente si hay publicaciones nuevas"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kalau di atas auto scroll kalau ada postingan baru"
           }
         },
         "nl" : {
@@ -20810,6 +28526,12 @@
             "value" : "Cuándo descargar automáticamente medios publicados por otros"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapan mengunduh otomatis media yang diposting oleh orang lain"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20824,6 +28546,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cuando marcas una publicación, aparecerá aquí."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saat Anda mem-bookmark sebuah postingan, postingan tersebut akan muncul di sini."
           }
         },
         "nl" : {
@@ -20842,6 +28570,12 @@
             "value" : "¿Qué relays deberían usar otros para buscar publicaciones para la cuenta: %@? (elija 3 máximo)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays mana yang harus digunakan orang lain untuk menemukan postingan untuk akun: %@? (pilih maks 3)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20858,6 +28592,12 @@
             "value" : "¿Qué relays deberían usar otros para acceder a la cuenta: %@? (elija 3 máximo)"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays mana yang harus digunakan orang lain untuk mencapai akun: %@? (pilih maks 3)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20872,6 +28612,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "¿Qué relays deberían usar otros para enviar mensajes privados a %@? (elija 3 máximo)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "relays mana yang harus digunakan orang lain untuk mengirim pesan pribadi ke %@? (pilih maks 3)"
           }
         },
         "nl" : {
@@ -20891,6 +28637,12 @@
             "value" : "No descargará medios ni vistas previas."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak akan mengunduh media dan pratinjau"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20908,6 +28660,12 @@
             "value" : "Mostrará el saldo en la barra lateral."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akan menunjukkan keseimbangan di side bar"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20923,6 +28681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mostrará desde qué aplicación/cliente se publicó algo, si está disponible"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akan menunjukkan dari aplikasi/klien mana sesuatu diposting, jika tersedia"
           }
         },
         "nl" : {
@@ -20943,6 +28707,12 @@
           }
         },
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Normal"
@@ -20971,6 +28741,12 @@
             "value" : "Apagado"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mati"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20994,6 +28770,12 @@
             "value" : "Estricto"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketat"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21008,6 +28790,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "escribir"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menulis"
           }
         },
         "nl" : {
@@ -21026,6 +28814,12 @@
             "value" : "Escribe: publicas en este relay, para que otros lean desde allí."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tulis: Anda memposting ke relay ini, sehingga orang lain membaca dari sana."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21042,6 +28836,12 @@
             "value" : "wss://"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss: //"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21054,6 +28854,12 @@
       "comment" : "Placeholder for entering a relay URL",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://nostr.relay.url.here"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "wss://nostr.relay.url.here"
@@ -21075,6 +28881,12 @@
             "value" : "wss://relay..."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wss://relay..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21091,6 +28903,12 @@
             "state" : "translated",
             "value" : "WTF"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WTF"
+          }
         }
       }
     },
@@ -21102,6 +28920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "y"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kamu"
           }
         },
         "nl" : {
@@ -21121,6 +28945,12 @@
             "value" : "Yaks"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yak"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21135,6 +28965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Año"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahun"
           }
         },
         "nl" : {
@@ -21152,6 +28988,12 @@
             "state" : "translated",
             "value" : "tú · anónimo"
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kamu · segera"
+          }
         }
       }
     },
@@ -21162,6 +29004,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aún no sigues a nadie, visita la pestaña explorar y sigue a algunas personas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda belum mengikuti siapa pun, kunjungi tab jelajahi dan ikuti beberapa orang"
           }
         },
         "nl" : {
@@ -21178,6 +29026,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aún no sigues a nadie, visita la pestaña Explorar y sigue a algunas personas."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda belum mengikuti siapa pun, kunjungi tab Jelajahi dan ikuti beberapa orang"
           }
         },
         "nl" : {
@@ -21197,6 +29051,12 @@
             "value" : "Estás utilizando una cuenta de solo lectura.\n\nCambie a otra cuenta o agregue la clave privada para utilizar esta cuenta por completo."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda menggunakan akun hanya-baca.\n\nBeralih ke akun lain atau tambahkan kunci pribadi untuk menggunakan akun ini sepenuhnya."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21212,6 +29072,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No has recibido ningún mensaje"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda belum menerima pesan apa pun"
           }
         },
         "nl" : {
@@ -21230,6 +29096,12 @@
             "value" : "Su billetera **Alby** ahora está conectada con **Nostur**, ¡ahora puede disfrutar de una experiencia zapping perfecta!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dompet **Alby** Anda sekarang terhubung dengan **Nostur**, kini Anda dapat menikmati pengalaman zapping yang lancar!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21246,6 +29118,12 @@
             "value" : "Su dirección para recibir zaps se ha configurado en: %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alamat Anda untuk menerima zaps telah disetel ke: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21260,6 +29138,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tu saldo:"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saldo Anda:"
           }
         },
         "nl" : {
@@ -21279,6 +29163,12 @@
             "value" : "Su nombre"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Namamu"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21294,6 +29184,12 @@
             "state" : "translated",
             "value" : "Su clave privada controla su cuenta. Nunca lo compartas con nadie. Cualquier persona con esta clave puede acceder completamente a su cuenta y publicar como usted."
           }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunci pribadi Anda mengontrol akun Anda. Jangan pernah membaginya dengan siapa pun. Siapa pun yang memiliki kunci ini dapat mengakses sepenuhnya akun Anda dan memposting sebagai Anda."
+          }
         }
       }
     },
@@ -21304,6 +29200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Su informe es público, otros usuarios pueden utilizar su informe para mejorar la red."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laporan Anda bersifat publik, pengguna lain dapat menggunakan laporan Anda untuk meningkatkan jaringan"
           }
         },
         "nl" : {
@@ -21322,6 +29224,12 @@
             "value" : "Su billetera ahora está conectada con **Nostur**, ¡ahora puede disfrutar de una experiencia de zapping perfecta!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dompet Anda sekarang terhubung dengan **Nostur**, kini Anda dapat menikmati pengalaman zapping yang lancar!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21336,6 +29244,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zap cantidad personalizada"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah khusus Zap"
           }
         },
         "nl" : {
@@ -21355,6 +29269,12 @@
             "value" : "Zap falló para [contacto](nostur:p:%@).\n%@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zap gagal untuk [kontak](nostur:p:%@).\n%@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21370,6 +29290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zap recibo de"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zap tanda terima dari"
           }
         },
         "nl" : {
@@ -21389,6 +29315,12 @@
             "value" : "Zappedido"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapped"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21404,6 +29336,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zappedido %@"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapped %@"
           }
         },
         "nl" : {
@@ -21424,6 +29362,12 @@
             "value" : "Zapped %@ sentado %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapped %@ dengan %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21440,6 +29384,12 @@
             "value" : "Zapmarco de tiempo de alimentación ped"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerangka waktu umpan Zapped"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21452,6 +29402,12 @@
       "comment" : "Setting heading on settings screen",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapping"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zapping"
@@ -21474,6 +29430,12 @@
             "value" : "zaps"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zaps"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21486,6 +29448,12 @@
       "comment" : "Tab title\nTitle of list of zaps screen",
       "localizations" : {
         "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaps"
+          }
+        },
+        "id" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zaps"
@@ -21508,6 +29476,12 @@
             "value" : "Zaps falló en: %@ (tiempo de espera)."
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaps gagal pada: %@ (Waktu habis)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21523,6 +29497,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Es posible que Zaps haya fallado en: %@."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaps mungkin gagal pada: %@."
           }
         },
         "nl" : {
@@ -21543,6 +29523,12 @@
             "value" : "Zaps recibido recientemente"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaps diterima baru-baru ini"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21557,6 +29543,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zaps que recibiste aparecerá aquí"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaps yang Anda terima akan muncul di sini"
           }
         },
         "nl" : {

--- a/Nostur/Localizable.xcstrings
+++ b/Nostur/Localizable.xcstrings
@@ -525,7 +525,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#asknostr](buka:t:asknostr)"
+            "value" : "[#asknostr](nostur:t:asknostr)"
           }
         },
         "nl" : {
@@ -569,7 +569,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#bitcoin](lihat:t:bitcoin)"
+            "value" : "[#bitcoin](nostur:t:bitcoin)"
           }
         },
         "nl" : {
@@ -591,7 +591,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#rantai kopi](nostur:t:rantai kopi)"
+            "value" : "[#coffeechain](nostur:t:coffeechain)"
           }
         },
         "nl" : {
@@ -657,7 +657,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#grownostr](lihat:t:grownostr)"
+            "value" : "[#grownostr](nostur:t:grownostr)"
           }
         },
         "nl" : {
@@ -723,7 +723,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#nostr](lihat:t:nostr)"
+            "value" : "[#nostr](nostur:t:nostr)"
           }
         },
         "nl" : {
@@ -767,7 +767,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[#zapathon](lihat:t:zapathon)"
+            "value" : "[#zapathon](nostur:t:zapathon)"
           }
         },
         "nl" : {
@@ -1698,7 +1698,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ mem-posting ulang"
+            "value" : "%@ memposting ulang"
           }
         },
         "nl" : {
@@ -2813,7 +2813,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1w"
+            "value" : "1 minggu"
           }
         },
         "nl" : {
@@ -5708,7 +5708,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tembolok"
+            "value" : "Cache"
           }
         },
         "nl" : {
@@ -5981,7 +5981,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Memeriksa apa yang Anda ikuti zapped..."
+            "value" : "Memeriksa postingan yang dikirimi zap oleh orang yang Anda ikuti..."
           }
         },
         "nl" : {
@@ -7062,7 +7062,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hubungkan dompet **Alby** Anda dengan **Nostur** untuk pengalaman zapping yang lancar"
+            "value" : "Hubungkan dompet **Alby** Anda dengan **Nostur** agar kirim zap lebih lancar"
           }
         },
         "nl" : {
@@ -7084,7 +7084,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hubungkan dompet kompatibel NWC Anda dengan **Nostur** untuk pengalaman zapping yang lancar"
+            "value" : "Hubungkan dompet kompatibel NWC Anda dengan **Nostur** agar kirim zap lebih lancar"
           }
         },
         "nl" : {
@@ -8126,7 +8126,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Penghitung untuk balasan, suka, zaps dll."
+            "value" : "Penghitung balasan, suka, zap, dan lainnya"
           }
         },
         "nl" : {
@@ -8284,7 +8284,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Buat Sarang Audio Anda"
+            "value" : "Buat Audio Nest Anda"
           }
         },
         "nl" : {
@@ -8600,7 +8600,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basis Data & Tembolok"
+            "value" : "Database & Cache"
           }
         },
         "nl" : {
@@ -8860,7 +8860,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Jumlah zap default"
+            "value" : "Jumlah zap bawaan"
           }
         },
         "nl" : {
@@ -10708,7 +10708,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zaps gagal"
+            "value" : "zap gagal"
           }
         },
         "nl" : {
@@ -10936,7 +10936,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pengambilan suka/zaps/balasan dihitung saat postingan muncul"
+            "value" : "Mengambil jumlah suka/zap/balasan saat postingan muncul"
           }
         },
         "nl" : {
@@ -13690,7 +13690,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sarang Langsung atau streaming dari berikut"
+            "value" : "Nest live atau streaming dari orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -14081,7 +14081,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mode Data Rendah"
+            "value" : "Mode Hemat Data"
           }
         },
         "nl" : {
@@ -14104,7 +14104,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modus Data Rendah"
+            "value" : "Mode Hemat Data"
           }
         },
         "nl" : {
@@ -14401,7 +14401,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tembolok media"
+            "value" : "Cache media"
           }
         },
         "nl" : {
@@ -15286,7 +15286,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Judul sarang"
+            "value" : "Judul Nest"
           }
         },
         "nl" : {
@@ -15308,7 +15308,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Server Audio Sarang"
+            "value" : "Server Audio Nest"
           }
         },
         "nl" : {
@@ -15330,7 +15330,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Server sarang"
+            "value" : "Server Nest"
           }
         },
         "nl" : {
@@ -15352,7 +15352,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Server sarang:"
+            "value" : "Server Nest:"
           }
         },
         "nl" : {
@@ -15375,7 +15375,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sarang akan diumumkan pada:"
+            "value" : "Nest akan diumumkan di:"
           }
         },
         "nl" : {
@@ -15981,7 +15981,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zaps baru"
+            "value" : "Zap baru"
           }
         },
         "nl" : {
@@ -18457,7 +18457,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Postingan dari siapa pun yang paling banyak zap dipedulikan oleh orang yang Anda ikuti"
+            "value" : "Postingan dari siapa pun yang paling banyak dikirimi zap oleh orang yang Anda ikuti"
           }
         },
         "nl" : {
@@ -18914,7 +18914,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zap Pribadi"
+            "value" : "Zap pribadi"
           }
         },
         "nl" : {
@@ -20770,7 +20770,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingat jumlah ini untuk semua zaps"
+            "value" : "Ingat jumlah ini untuk semua zap"
           }
         },
         "nl" : {
@@ -21489,7 +21489,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "mem-posting ulang"
+            "value" : "memposting ulang"
           }
         },
         "nl" : {
@@ -24089,7 +24089,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tampilkan nilai fiat zaps"
+            "value" : "Tampilkan nilai fiat zap"
           }
         },
         "nl" : {
@@ -24679,7 +24679,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mulai Sarang"
+            "value" : "Mulai Nest"
           }
         },
         "nl" : {
@@ -24701,7 +24701,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mulai Nest (Ruang Audio)"
+            "value" : "Mulai Nest (ruang audio)"
           }
         },
         "nl" : {
@@ -24908,7 +24908,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dukung orang-orang yang menyusun daftar berkualitas tinggi dengan zapping mereka"
+            "value" : "Dukung orang yang menyusun daftar berkualitas dengan mengirim zap kepada mereka"
           }
         },
         "nl" : {
@@ -25750,7 +25750,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Umpan Zapped menampilkan postingan dari siapa saja yang paling banyak zapped oleh orang yang Anda ikuti dalam %lld jam terakhir"
+            "value" : "Feed Zapped menampilkan postingan dari siapa pun yang paling banyak dikirimi zap oleh orang yang Anda ikuti dalam %lld jam terakhir"
           }
         },
         "nl" : {
@@ -27570,7 +27570,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zaps tidak terverifikasi"
+            "value" : "Zap tidak terverifikasi"
           }
         },
         "nl" : {
@@ -29099,7 +29099,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dompet **Alby** Anda sekarang terhubung dengan **Nostur**, kini Anda dapat menikmati pengalaman zapping yang lancar!"
+            "value" : "Dompet **Alby** Anda sekarang terhubung dengan **Nostur**. Sekarang Anda bisa mengirim zap dengan lebih lancar!"
           }
         },
         "nl" : {
@@ -29121,7 +29121,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alamat Anda untuk menerima zaps telah disetel ke: %@"
+            "value" : "Alamat Anda untuk menerima zap telah diatur ke: %@"
           }
         },
         "nl" : {
@@ -29227,7 +29227,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dompet Anda sekarang terhubung dengan **Nostur**, kini Anda dapat menikmati pengalaman zapping yang lancar!"
+            "value" : "Dompet Anda sekarang terhubung dengan **Nostur**. Sekarang Anda bisa mengirim zap dengan lebih lancar!"
           }
         },
         "nl" : {
@@ -29295,7 +29295,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zap tanda terima dari"
+            "value" : "Tanda terima zap dari"
           }
         },
         "nl" : {
@@ -29341,7 +29341,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapped %@"
+            "value" : "Mengirim zap ke %@"
           }
         },
         "nl" : {
@@ -29365,7 +29365,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapped %@ dengan %@"
+            "value" : "Mengirim zap %@ sats %@"
           }
         },
         "nl" : {
@@ -29387,7 +29387,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kerangka waktu umpan Zapped"
+            "value" : "Rentang waktu feed Zapped"
           }
         },
         "nl" : {
@@ -29410,7 +29410,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapping"
+            "value" : "Mengirim zap"
           }
         },
         "nl" : {
@@ -29433,7 +29433,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zaps"
+            "value" : "zap"
           }
         },
         "nl" : {
@@ -29456,7 +29456,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaps"
+            "value" : "Zap"
           }
         },
         "nl" : {
@@ -29479,7 +29479,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaps gagal pada: %@ (Waktu habis)."
+            "value" : "Zap gagal pada: %@ (waktu habis)."
           }
         },
         "nl" : {
@@ -29502,7 +29502,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaps mungkin gagal pada: %@."
+            "value" : "Zap mungkin gagal pada: %@."
           }
         },
         "nl" : {
@@ -29526,7 +29526,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaps diterima baru-baru ini"
+            "value" : "Zap yang diterima baru-baru ini"
           }
         },
         "nl" : {
@@ -29548,7 +29548,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaps yang Anda terima akan muncul di sini"
+            "value" : "Zap yang Anda terima akan muncul di sini"
           }
         },
         "nl" : {


### PR DESCRIPTION
## Summary
- Add Bahasa Indonesia (id) translations to the main app string catalog
- Add Bahasa Indonesia translations to the Highlight with Nostur InfoPlist string catalog
- Preserve existing English, Dutch, and Spanish localizations

## Validation
- Verified all catalog entries have Indonesian localizations
- Verified printf-style placeholders are preserved
- Built successfully in Xcode

Made with Xcode Codex ChatGPT-5.5 and Grok Expert.