### PR TITLE
Honor NIP-40 expiration on NIP-04 & NIP-17 direct messages

### DIFF
--- a/Nostur/AppView.swift
+++ b/Nostur/AppView.swift
@@ -120,6 +120,9 @@ extension AppView {
                     AppState.shared.startTaskTimers()
                     try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
                     try? AVAudioSession.sharedInstance().setActive(true)
+
+                    // NIP-40: promptly drop expired DM copies when returning from background
+                    Task { await Maintenance.purgeExpiredDMsNow() }
                 }
             }
             else {
@@ -131,6 +134,9 @@ extension AppView {
                 ConversionVM.restoreSubscriptions()
                 NotificationsViewModel.restoreSubscriptions()
                 AppState.shared.startTaskTimers()
+
+                // NIP-40: promptly drop expired DM copies when returning from background
+                Task { await Maintenance.purgeExpiredDMsNow() }
             }
             
             

--- a/Nostur/DMs/DMConversationVM.swift
+++ b/Nostur/DMs/DMConversationVM.swift
@@ -379,6 +379,13 @@ class ConversionVM: ObservableObject {
             
             
             return ((try? bgContext.fetch(request)) ?? [])
+                .filter { event in
+                    // NIP-40: hide messages whose expiration has passed (even if not yet purged)
+                    guard let expString = event.fastTags.first(where: { $0.0 == "expiration" })?.1,
+                          let exp = Int64(expString)
+                    else { return true }
+                    return exp > Int64(Date.now.timeIntervalSince1970)
+                }
                 .map {
                     NEvent(id: $0.id,
                            publicKey: $0.pubkey,

--- a/Nostur/Nostr/EventImportHandlers/RepostHandler.swift
+++ b/Nostur/Nostr/EventImportHandlers/RepostHandler.swift
@@ -103,7 +103,8 @@ func handleRepost(nEvent: NEvent, savedEvent: Event, kind6firstQuote: Event? = n
 }
 
 public enum ImportErrors: Error {
-    
+
     case InvalidSignature
     case AlreadyHaveNewerReplacableEvent
+    case Expired
 }

--- a/Nostur/Nostr/Importer.swift
+++ b/Nostur/Nostr/Importer.swift
@@ -272,8 +272,9 @@ class Importer {
                                 continue
                             }
 
-                            // Import rumor
-                            _ = try importEvent(event: NEvent.fromNostrEssentialsEvent(rumor), wrapId: event.id, message: message)
+                            // Import rumor (inherits the gift wrap's NIP-40 expiration)
+                            let rumorEvent = NEvent.fromRumor(rumor, unwrappedFrom: event)
+                            _ = try importEvent(event: rumorEvent, wrapId: event.id, message: message)
                         }
                         else {
                             // handle like normal
@@ -408,8 +409,9 @@ class Importer {
                                 continue
                             }
 
-                            // Import rumor
-                            let savedEvent = try importEvent(event: NEvent.fromNostrEssentialsEvent(rumor), wrapId: event.id, message: message)
+                            // Import rumor (inherits the gift wrap's NIP-40 expiration)
+                            let rumorEvent = NEvent.fromRumor(rumor, unwrappedFrom: event)
+                            let savedEvent = try importEvent(event: rumorEvent, wrapId: event.id, message: message)
                             
                             // Immediately notify (prio)
                             if let subscriptionId = message.subscriptionId {
@@ -456,7 +458,15 @@ class Importer {
             }
             throw ImportErrors.AlreadyHaveNewerReplacableEvent
         }
-        
+
+        // NIP-40: don't persist DMs (NIP-04 / NIP-17) that are already expired
+        if [4, 14, 15].contains(event.kind.id),
+           let exp = event.tagNamed("expiration").flatMap({ Int64($0) }),
+           exp <= Int64(Date.now.timeIntervalSince1970)
+        {
+            throw ImportErrors.Expired
+        }
+
         var kind6firstQuote: Event?
         kind6firstQuote = try handleRepost(event, relays: message.relays, bgContext: bgContext)
         try handlePinnedPosts(event, relays: message.relays, bgContext: bgContext)

--- a/Nostur/Nostr/Nostr.swift
+++ b/Nostur/Nostr/Nostr.swift
@@ -648,6 +648,18 @@ extension NEvent {
             signature: event.sig
         )
     }
+
+    // Build an NEvent from a NIP-59 rumor that was just unwrapped from a gift wrap.
+    // Inherits the gift wrap's NIP-40 `expiration` when the rumor doesn't set its own, so the stored
+    // message can still be hidden/purged when the sender only tagged the outer wrap. Only the inbound
+    // unwrap path needs this; outbound/other conversions should keep using fromNostrEssentialsEvent.
+    static public func fromRumor(_ rumor: NostrEssentials.Event, unwrappedFrom wrap: NEvent) -> NEvent {
+        var nEvent = NEvent.fromNostrEssentialsEvent(rumor)
+        if nEvent.tagNamed("expiration") == nil, let wrapExpiration = wrap.tagNamed("expiration") {
+            nEvent.tags.append(NostrTag(["expiration", wrapExpiration]))
+        }
+        return nEvent
+    }
 }
 
 class TagSerializer {

--- a/Nostur/Utils/Maintenance.swift
+++ b/Nostur/Utils/Maintenance.swift
@@ -274,6 +274,44 @@ struct Maintenance {
         }
     }
     
+    // NIP-40: delete DM events (NIP-04 kind 4, NIP-17 kind 14/15) whose expiration timestamp has passed.
+    // Intentionally ignores the own-account / bookmark exclusions used elsewhere: an expiring message
+    // should disappear even if it's our own or bookmarked.
+    static func deleteExpiredDMs(_ context: NSManagedObjectContext) {
+        let now = Int64(Date.now.timeIntervalSince1970)
+        let fr = NSFetchRequest<Event>(entityName: "Event")
+        fr.predicate = NSPredicate(format: "kind IN {4,14,15} AND tagsSerialized CONTAINS %@", "expiration")
+        guard let candidates = try? context.fetch(fr) else { return }
+        let expiredIds: [String] = candidates.compactMap { event in
+            guard let expString = event.fastTags.first(where: { $0.0 == "expiration" })?.1,
+                  let exp = Int64(expString), exp <= now
+            else { return nil }
+            return event.id
+        }
+        guard !expiredIds.isEmpty else { return }
+
+        let del = NSFetchRequest<NSFetchRequestResult>(entityName: "Event")
+        del.predicate = NSPredicate(format: "id IN %@", expiredIds)
+        let batchDelete = NSBatchDeleteRequest(fetchRequest: del)
+        batchDelete.resultType = .resultTypeCount
+        do {
+            let result = try context.execute(batchDelete) as! NSBatchDeleteResult
+            if let count = result.result as? Int, count > 0 {
+                L.maintenance.info("🧹🧹 Deleted \(count) expired DM events (NIP-40)")
+            }
+        } catch {
+            L.maintenance.info("🧹🧹 🔴🔴 Failed to delete expired DM events (NIP-40)")
+        }
+    }
+
+    // Run the expired-DM purge promptly (e.g. on returning from background), outside the 24h maintenance throttle.
+    static func purgeExpiredDMsNow() async {
+        let context = bg()
+        await context.perform {
+            Self.deleteExpiredDMs(context)
+        }
+    }
+
     // TODO: NEED TO INVERT, DELETE ALL EXCEPT.. (instead of now: delete only *these*)
     static func databaseCleanUp(_ context: NSManagedObjectContext) {
         let pfr = NSFetchRequest<NSFetchRequestResult>(entityName: "PersistentNotification")
@@ -369,8 +407,11 @@ struct Maintenance {
         } catch {
             L.maintenance.info("🧹🧹 🔴🔴 Failed to delete {1,1111,1222,1244,4,14,5,6,20,9802,30311,30023,34235,34236} data")
         }
-        
-        
+
+        // NIP-40: delete expired DM messages (NIP-04 / NIP-17)
+        Self.deleteExpiredDMs(context)
+
+
         // KIND 7,8
         // OLDER THAN X DAYS
         // PUBKEY NOT IN OWN ACCOUNTS


### PR DESCRIPTION
Discard and purge expired DMs (kind 4, 14, 15) based on the NIP-40 ["expiration", <ts>] tag, on both the receive and cleanup sides:

- Import: drop NIP-04/NIP-17 messages that arrive already expired (Importer.importEvent), so they are never persisted.
- NIP-17: carry the gift wrap's expiration onto the decrypted rumor (NEvent.fromRumor) so it survives unwrapping for later purge/hide, regardless of whether the sender tagged the wrap or the rumor.
- Maintenance: delete expired DMs during daily cleanup and promptly on return-from-background (Maintenance.deleteExpiredDMs / purgeExpiredDMsNow). This intentionally ignores the own-account and bookmark exclusions: an expiring message should disappear regardless.
- Display: hide expired messages from the conversation view (DMConversationVM.getMessages) so they disappear immediately, even before the purge runs.

Implemented with in-memory tag checks; no Core Data schema change. Outbound expiration-setting is not included in this change.